### PR TITLE
Fix relative path for ProjectsEventsReportCall

### DIFF
--- a/clouderrorreporting/v1beta1/clouderrorreporting-gen.go
+++ b/clouderrorreporting/v1beta1/clouderrorreporting-gen.go
@@ -1346,7 +1346,7 @@ func (c *ProjectsEventsReportCall) doRequest(alt string) (*http.Response, error)
 	reqHeaders.Set("Content-Type", "application/json")
 	c.urlParams_.Set("alt", alt)
 	c.urlParams_.Set("prettyPrint", "false")
-	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta1/{+projectName}/events:report")
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta1/projects/{+projectName}/events:report")
 	urls += "?" + c.urlParams_.Encode()
 	req, err := http.NewRequest("POST", urls, body)
 	if err != nil {


### PR DESCRIPTION
There is at least one occurrence of invalid URI when attempting to report an error, which results in a 404.

With the proposed fix the issue is solved; this is however, likely incomplete as other URIs might have the same issue and generally the generator of this code should be fixed instead.

Documentation confirms the correct URL: https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report