### PR TITLE
Add Email to Payload struct

### DIFF
--- a/idtoken/validate.go
+++ b/idtoken/validate.go
@@ -36,6 +36,7 @@ type Payload struct {
 	Expires  int64                  `json:"exp"`
 	IssuedAt int64                  `json:"iat"`
 	Subject  string                 `json:"sub,omitempty"`
+	Email  	 string                 `json:"email,omitempty"`
 	Claims   map[string]interface{} `json:"-"`
 }
 


### PR DESCRIPTION
Getting the email is a useful feature of the JWT authentication feature. It's part of the REST API. Don't know why if there was a reason it was not here, or if it was a deliberate omission.