### PR TITLE
User agent prefix

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -43,6 +43,7 @@ Glenn Lewis <gmlewis@google.com>
 Ivan Krasin <krasin@golang.org>
 Jason Hall <jasonhall@google.com>
 Johan Euphrosine <proppy@google.com>
+Ken Egozi <kenegozi@google.com>
 Kostik Shtoyk <kostik@google.com>
 Kunpei Sakai <namusyaka@gmail.com>
 Matthew Dolan <dolan@lightstep.com>

--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -768,14 +768,15 @@ func (a *API) GenerateCode() ([]byte, error) {
 	pn(" client *http.Client")
 	pn(" BasePath string // API endpoint base URL")
 	pn(" UserAgent string // optional additional User-Agent fragment")
+	pn(" UserAgentPrefix string // optional User-Agent prefix fragment")
 
 	for _, res := range a.doc.Resources {
 		pn("\n\t%s\t*%s", resourceGoField(res, nil), resourceGoType(res))
 	}
 	pn("}")
 	pn("\nfunc (s *%s) userAgent() string {", service)
-	pn(` if s.UserAgent == "" { return googleapi.UserAgent }`)
-	pn(` return googleapi.UserAgent + " " + s.UserAgent`)
+	pn(` if s.UserAgent == "" && s.UserAgentPrefix == "" { return googleapi.UserAgent }`)
+	pn(` return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)`)
 	pn("}\n")
 
 	for _, res := range a.doc.Resources {

--- a/google-api-go-generator/gen_test.go
+++ b/google-api-go-generator/gen_test.go
@@ -100,9 +100,11 @@ func TestScope(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		if got := scopeIdentifier(disco.Scope{ID: test[0]}); got != test[1] {
-			t.Errorf("scopeIdentifier(%q) got %q, want %q", test[0], got, test[1])
-		}
+		t.Run(test[1], func(t *testing.T) {
+			if got := scopeIdentifier(disco.Scope{ID: test[0]}); got != test[1] {
+				t.Errorf("scopeIdentifier(%q) got %q, want %q", test[0], got, test[1])
+			}
+		})
 	}
 }
 
@@ -168,9 +170,11 @@ func TestDepunct(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		if got := depunct(test.in, test.needCap); got != test.want {
-			t.Errorf("depunct(%q,%v) = %q; want %q", test.in, test.needCap, got, test.want)
-		}
+		t.Run(test.in, func(t *testing.T) {
+			if got := depunct(test.in, test.needCap); got != test.want {
+				t.Errorf("depunct(%q,%v) = %q; want %q", test.in, test.needCap, got, test.want)
+			}
+		})
 	}
 }
 
@@ -192,9 +196,11 @@ func TestRenameVersion(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		if got := renameVersion(test.version); got != test.want {
-			t.Errorf("renameVersion(%q) = %q; want %q", test.version, got, test.want)
-		}
+		t.Run(test.version, func(t *testing.T) {
+			if got := renameVersion(test.version); got != test.want {
+				t.Errorf("renameVersion(%q) = %q; want %q", test.version, got, test.want)
+			}
+		})
 	}
 }
 
@@ -206,11 +212,13 @@ func TestSupportsPaging(t *testing.T) {
 	api.PopulateSchemas()
 	res := api.doc.Resources[0]
 	for _, meth := range api.resourceMethods(res) {
-		_, _, got := meth.supportsPaging()
-		want := strings.HasPrefix(meth.m.Name, "yes")
-		if got != want {
-			t.Errorf("method %s supports paging: got %t, want %t", meth.m.Name, got, want)
-		}
+		t.Run(meth.m.Name, func(t *testing.T) {
+			_, _, got := meth.supportsPaging()
+			want := strings.HasPrefix(meth.m.Name, "yes")
+			if got != want {
+				t.Errorf("method %s supports paging: got %t, want %t", meth.m.Name, got, want)
+			}
+		})
 	}
 }
 

--- a/google-api-go-generator/testdata/any.want
+++ b/google-api-go-generator/testdata/any.want
@@ -119,18 +119,19 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 
 	Projects *ProjectsService
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 func NewProjectsService(s *Service) *ProjectsService {

--- a/google-api-go-generator/testdata/arrayofarray-1.want
+++ b/google-api-go-generator/testdata/arrayofarray-1.want
@@ -105,16 +105,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 // GeoJsonMultiPolygon: Multi Polygon

--- a/google-api-go-generator/testdata/arrayofenum.want
+++ b/google-api-go-generator/testdata/arrayofenum.want
@@ -105,16 +105,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 // Container: Represents a Google Tag Manager Container.

--- a/google-api-go-generator/testdata/arrayofmapofobjects.want
+++ b/google-api-go-generator/testdata/arrayofmapofobjects.want
@@ -105,16 +105,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 type Analyze struct {

--- a/google-api-go-generator/testdata/arrayofmapofstrings.want
+++ b/google-api-go-generator/testdata/arrayofmapofstrings.want
@@ -105,16 +105,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 type Analyze struct {

--- a/google-api-go-generator/testdata/blogger-3.want
+++ b/google-api-go-generator/testdata/blogger-3.want
@@ -134,9 +134,10 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 
 	BlogUserInfos *BlogUserInfosService
 
@@ -156,10 +157,10 @@ type Service struct {
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 func NewBlogUserInfosService(s *Service) *BlogUserInfosService {

--- a/google-api-go-generator/testdata/floats.want
+++ b/google-api-go-generator/testdata/floats.want
@@ -107,16 +107,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 // Utilization: CPU utilization policy.

--- a/google-api-go-generator/testdata/getwithoutbody.want
+++ b/google-api-go-generator/testdata/getwithoutbody.want
@@ -106,18 +106,19 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 
 	MetricDescriptors *MetricDescriptorsService
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 func NewMetricDescriptorsService(s *Service) *MetricDescriptorsService {

--- a/google-api-go-generator/testdata/http-body.want
+++ b/google-api-go-generator/testdata/http-body.want
@@ -119,18 +119,19 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 
 	Projects *ProjectsService
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 func NewProjectsService(s *Service) *ProjectsService {

--- a/google-api-go-generator/testdata/json-body.want
+++ b/google-api-go-generator/testdata/json-body.want
@@ -119,18 +119,19 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 
 	Projects *ProjectsService
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 func NewProjectsService(s *Service) *ProjectsService {

--- a/google-api-go-generator/testdata/mapofany.want
+++ b/google-api-go-generator/testdata/mapofany.want
@@ -105,16 +105,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 type JsonValue interface{}

--- a/google-api-go-generator/testdata/mapofarrayofobjects.want
+++ b/google-api-go-generator/testdata/mapofarrayofobjects.want
@@ -106,18 +106,19 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 
 	Atlas *AtlasService
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 func NewAtlasService(s *Service) *AtlasService {

--- a/google-api-go-generator/testdata/mapofint64strings.want
+++ b/google-api-go-generator/testdata/mapofint64strings.want
@@ -105,16 +105,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 type TestResultSummaryToolGroupTestSuite struct {

--- a/google-api-go-generator/testdata/mapofobjects.want
+++ b/google-api-go-generator/testdata/mapofobjects.want
@@ -105,16 +105,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 type Entity struct {

--- a/google-api-go-generator/testdata/mapofstrings-1.want
+++ b/google-api-go-generator/testdata/mapofstrings-1.want
@@ -106,18 +106,19 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 
 	Atlas *AtlasService
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 func NewAtlasService(s *Service) *AtlasService {

--- a/google-api-go-generator/testdata/param-rename.want
+++ b/google-api-go-generator/testdata/param-rename.want
@@ -107,9 +107,10 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 
 	Events *EventsService
 
@@ -117,10 +118,10 @@ type Service struct {
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 func NewEventsService(s *Service) *EventsService {

--- a/google-api-go-generator/testdata/quotednum.want
+++ b/google-api-go-generator/testdata/quotednum.want
@@ -118,16 +118,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 // Creative: A creative and its classification data.

--- a/google-api-go-generator/testdata/repeated.want
+++ b/google-api-go-generator/testdata/repeated.want
@@ -106,18 +106,19 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 
 	Accounts *AccountsService
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 func NewAccountsService(s *Service) *AccountsService {

--- a/google-api-go-generator/testdata/required-query.want
+++ b/google-api-go-generator/testdata/required-query.want
@@ -106,18 +106,19 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 
 	Techs *TechsService
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 func NewTechsService(s *Service) *TechsService {

--- a/google-api-go-generator/testdata/resource-named-service.want
+++ b/google-api-go-generator/testdata/resource-named-service.want
@@ -119,18 +119,19 @@ func New(client *http.Client) (*APIService, error) {
 }
 
 type APIService struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 
 	Apps *AppsService
 }
 
 func (s *APIService) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 func NewAppsService(s *APIService) *AppsService {

--- a/google-api-go-generator/testdata/unfortunatedefaults.want
+++ b/google-api-go-generator/testdata/unfortunatedefaults.want
@@ -105,16 +105,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 // Thing: don't care

--- a/google-api-go-generator/testdata/variants.want
+++ b/google-api-go-generator/testdata/variants.want
@@ -105,16 +105,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 type GeoJsonGeometry map[string]interface{}

--- a/google-api-go-generator/testdata/wrapnewlines.want
+++ b/google-api-go-generator/testdata/wrapnewlines.want
@@ -105,16 +105,17 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client          *http.Client
+	BasePath        string // API endpoint base URL
+	UserAgent       string // optional additional User-Agent fragment
+	UserAgentPrefix string // optional User-Agent prefix fragment
 }
 
 func (s *Service) userAgent() string {
-	if s.UserAgent == "" {
+	if s.UserAgent == "" && s.UserAgentPrefix == "" {
 		return googleapi.UserAgent
 	}
-	return googleapi.UserAgent + " " + s.UserAgent
+	return strings.Trim(s.UserAgentPrefix + " " + googleapi.UserAgent + " " + s.UserAgent)
 }
 
 // Thing: don't care


### PR DESCRIPTION
Per the RFC at https://tools.ietf.org/html/rfc2616#section-14.43, "By convention, the product tokens are listed in order of their significance for identifying the application."

Support specifying a prefix to the user agent, so that a user could specify a more significant identifier for their requests.