### PR TITLE
internal/kokoro/synth: fix compilation errors

### DIFF
--- a/internal/kokoro/synth/sendpr/sendpr.go
+++ b/internal/kokoro/synth/sendpr/sendpr.go
@@ -1,5 +1,5 @@
-// Copyright 2020 Google Inc. All rights reserved.
-// Use of this source code is governed by the Apache 2.0
+// Copyright 2020 Google LLC.
+// Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 package main
@@ -28,9 +28,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	req := http.NewRequest("POST", "https://api.github.com/repos/googleapis/google-api-go-client/pulls", bytes.NewReader(body))
-	req.Headers.Set("Accept", "application/vnd.github.v3+json")
-	req.Headers.Set("Authorization", "token "+os.Getenv("GITHUB_TOKEN"))
+	req, err := http.NewRequest("POST", "https://api.github.com/repos/googleapis/google-api-go-client/pulls", bytes.NewReader(body))
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Authorization", "token "+os.Getenv("GITHUB_TOKEN"))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -38,10 +41,10 @@ func main() {
 	}
 	defer resp.Body.Close()
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode > 299 {
-		log.Fatal("non-OK response creating PR: %s", body)
+		log.Fatalf("non-OK response creating PR: %s", bodyBytes)
 	}
 
-	log.Print("PR created: %s", body)
+	log.Printf("PR created: %s", bodyBytes)
 }

--- a/internal/kokoro/synth/synth.sh
+++ b/internal/kokoro/synth/synth.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2020 Google LLC.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
 
 set -e -x
 


### PR DESCRIPTION
#489 had code that didn't compile (whoops), but strangely didn't get picked up by tests.