### PR TITLE
internal: re-enable generation of customsearch

### DIFF
--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -124,7 +124,6 @@ func (e *compileError) Error() string {
 
 // skipAPIGeneration is a set of APIs to not generate when generating all clients.
 var skipAPIGeneration = map[string]bool{
-	"customsearch:v1": true,
 	"sql:v1beta4":     true,
 }
 

--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -124,7 +124,7 @@ func (e *compileError) Error() string {
 
 // skipAPIGeneration is a set of APIs to not generate when generating all clients.
 var skipAPIGeneration = map[string]bool{
-	"sql:v1beta4":     true,
+	"sql:v1beta4": true,
 }
 
 func main() {


### PR DESCRIPTION
This should no longer be an issue to generate now that we make sure we only re-generate newer revisions.

Fixes: #471