### PR TITLE
transport/grpc: support GOOGLE_API_USE_MTLS=always

### DIFF
--- a/transport/grpc/dial.go
+++ b/transport/grpc/dial.go
@@ -184,7 +184,36 @@ func dial(ctx context.Context, insecure bool, o *internal.DialSettings) (*grpc.C
 		grpcOpts = append(grpcOpts, timeoutDialerOption)
 	}
 
+	// NOTE(cbro): this is used only by the nightly mtls_smoketest and should
+	// not otherwise be used. It will be removed or renamed at some point.
+	if os.Getenv("GOOGLE_API_USE_MTLS") == "always" {
+		o.Endpoint = generateDefaultMtlsEndpoint(o.Endpoint)
+	}
+
 	return grpc.DialContext(ctx, o.Endpoint, grpcOpts...)
+}
+
+// generateDefaultMtlsEndpoint attempts to derive the mTLS version of the
+// defaultEndpoint via regex, and returns defaultEndpoint if unsuccessful.
+//
+// We need to applying the following 2 transformations:
+// 1. pubsub.googleapis.com to pubsub.mtls.googleapis.com
+// 2. pubsub.sandbox.googleapis.com to pubsub.mtls.sandbox.googleapis.com
+//
+// TODO(cbro): In the future, the mTLS endpoint will be read from Service Config
+// and passed in as defaultMtlsEndpoint instead of generated from defaultEndpoint,
+// and this function will be removed.
+func generateDefaultMtlsEndpoint(defaultEndpoint string) string {
+	var domains = []string{
+		".sandbox.googleapis.com", // must come first because .googleapis.com is a substring
+		".googleapis.com",
+	}
+	for _, domain := range domains {
+		if strings.Contains(defaultEndpoint, domain) {
+			return strings.Replace(defaultEndpoint, domain, ".mtls"+domain, -1)
+		}
+	}
+	return defaultEndpoint
 }
 
 func addOCStatsHandler(opts []grpc.DialOption, settings *internal.DialSettings) []grpc.DialOption {


### PR DESCRIPTION
This will swap "foo.googleapis.com" to "foo.mtls.googleapis.com" and used by mtls_smoketest.