### PR TITLE
gensupport: reintroduce retry deadline

### DIFF
--- a/internal/gensupport/resumable_test.go
+++ b/internal/gensupport/resumable_test.go
@@ -301,6 +301,57 @@ func TestCancelUploadBasic(t *testing.T) {
 	}
 }
 
+func TestRetry_Bounded(t *testing.T) {
+	const (
+		chunkSize = 90
+		mediaSize = 300
+	)
+	media := strings.NewReader(strings.Repeat("a", mediaSize))
+
+	tr := &interruptibleTransport{
+		buf: make([]byte, 0, mediaSize),
+		events: []event{
+			{"bytes 0-89/*", http.StatusServiceUnavailable},
+			{"bytes 0-89/*", http.StatusServiceUnavailable},
+		},
+		bodies: bodyTracker{},
+	}
+
+	rx := &ResumableUpload{
+		Client:    &http.Client{Transport: tr},
+		Media:     NewMediaBuffer(media, chunkSize),
+		MediaType: "text/plain",
+		Callback:  func(int64) {},
+	}
+
+	oldRetryDeadline := retryDeadline
+	retryDeadline = time.Second
+	defer func() { retryDeadline = oldRetryDeadline }()
+
+	oldBackoff := backoff
+	backoff = func() Backoff { return new(PauseForeverBackoff) }
+	defer func() { backoff = oldBackoff }()
+
+	resCode := make(chan int, 1)
+	go func() {
+		resp, err := rx.Upload(context.Background())
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		resCode <- resp.StatusCode
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Upload to complete")
+	case got := <-resCode:
+		if want, got := http.StatusServiceUnavailable, got; got != want {
+			t.Fatalf("want %d, got %d", want, got)
+		}
+	}
+}
+
 func TestRetry_EachChunkHasItsOwnRetryDeadline(t *testing.T) {
 	const (
 		chunkSize = 90

--- a/internal/gensupport/send.go
+++ b/internal/gensupport/send.go
@@ -72,6 +72,7 @@ func send(ctx context.Context, client *http.Client, req *http.Request) (*http.Re
 	// Loop to retry the request, up to the context deadline.
 	var pause time.Duration
 	bo := backoff()
+	quitAfter := time.After(retryDeadline)
 
 	for {
 		select {
@@ -83,6 +84,8 @@ func send(ctx context.Context, client *http.Client, req *http.Request) (*http.Re
 			}
 			return resp, err
 		case <-time.After(pause):
+		case <-quitAfter:
+			return resp, err
 		}
 
 		resp, err = client.Do(req.WithContext(ctx))

--- a/internal/gensupport/util_test.go
+++ b/internal/gensupport/util_test.go
@@ -36,3 +36,8 @@ func (bo *NoPauseBackoff) Pause() time.Duration { return 0 }
 type PauseOneSecond struct{}
 
 func (bo *PauseOneSecond) Pause() time.Duration { return time.Second }
+
+// PauseForeverBackoff implements backoff with infinite 1h pauses.
+type PauseForeverBackoff struct{}
+
+func (bo *PauseForeverBackoff) Pause() time.Duration { return time.Hour }


### PR DESCRIPTION
It turns out that ResumableUpload.Upload actually uses
SendRequest to send the request ultimately (via the
transferChunk and doUploadRequest methods). Therefore,
adding a retry to SendRequest effectively removes the
existing deadline for each chunk.

This commit re-adds a deadline like what was in the
original form of #528 as a safety mechanism so that callers
don't see new confusing hangs during the resumable upload.
The test that checked for indefinite retries in an upload
was also re-added.

In the future, it makes sense to either remove the retry
in ResumableUpload.Upload, or revert the changes in SendRequest
and create a new SendAndRetryRequest function instead. But
either of those (especially the first) seems complicated to
do in the immediate term. And the double retry loop we have
here is ultimately harmless because the outer loop will
immediately timeout once the inner loop is done retrying.

Fixes googleapis/google-cloud-go#2469