### PR TITLE
idtoken: support authorized_user credentials

### DIFF
--- a/idtoken/idtoken.go
+++ b/idtoken/idtoken.go
@@ -106,8 +106,6 @@ func tokenSourceFromBytes(ctx context.Context, data []byte, audience string, ds 
 		RefreshToken string `json:"refresh_token"`
 	}
 
-	fmt.Println(string(data))
-
 	if err := json.Unmarshal(data, &f); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow using personal GCP credentials.  Useful for command line utilities.