### PR TITLE
chore(internal/kokoro): add Go info to build logs

### DIFF
--- a/internal/kokoro/synth/synth.sh
+++ b/internal/kokoro/synth/synth.sh
@@ -7,6 +7,8 @@
 set -e -x
 
 cd $(dirname $0)/../../..
+go version
+go env
 
 pushd google-api-go-generator
 make all


### PR DESCRIPTION
These are nice to have in general. Trying to debug why this script
is updating the go.mod. See #594 as an example PR that is not
right.

Updates: #590