### PR TITLE
option: change WithGRPCDialOption to get options as arguments

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -129,16 +129,16 @@ func (w withGRPCConn) Apply(o *internal.DialSettings) {
 	o.GRPCConn = w.conn
 }
 
-// WithGRPCDialOption returns a ClientOption that appends a new grpc.DialOption
+// WithGRPCDialOption returns a ClientOption that appends new grpc.DialOptions
 // to an underlying gRPC dial. It does not work with WithGRPCConn.
-func WithGRPCDialOption(opt grpc.DialOption) ClientOption {
-	return withGRPCDialOption{opt}
+func WithGRPCDialOption(opts ...grpc.DialOption) ClientOption {
+	return withGRPCDialOption{opts}
 }
 
-type withGRPCDialOption struct{ opt grpc.DialOption }
+type withGRPCDialOption struct{ opts []grpc.DialOption }
 
 func (w withGRPCDialOption) Apply(o *internal.DialSettings) {
-	o.GRPCDialOpts = append(o.GRPCDialOpts, w.opt)
+	o.GRPCDialOpts = append(o.GRPCDialOpts, w.opts...)
 }
 
 // WithGRPCConnectionPool returns a ClientOption that creates a pool of gRPC

--- a/transport/grpc/dial_test.go
+++ b/transport/grpc/dial_test.go
@@ -41,8 +41,11 @@ func TestGRPCHook(t *testing.T) {
 
 	conn, err := Dial(ctx,
 		option.WithTokenSource(oauth2.StaticTokenSource(nil)), // No creds.
-		option.WithGRPCDialOption(expectedDialer),
-		option.WithGRPCDialOption(grpc.WithBlock()))
+		option.WithGRPCDialOption(
+			expectedDialer,
+			grpc.WithBlock(),
+		),
+	)
 	if err != context.Canceled {
 		t.Errorf("got %v, want %v", err, context.Canceled)
 	}


### PR DESCRIPTION
This is no big change but it would be easy to understand to take options as arguments, IMO

If you have any design thoughts here, please tell me about that!