### PR TITLE
chore(internal/kokoro): fix Go install

### DIFF
--- a/internal/kokoro/synth/synth.sh
+++ b/internal/kokoro/synth/synth.sh
@@ -9,10 +9,11 @@ set -e -x
 cd $(dirname $0)/../../..
 
 # Install Go 1.15
+tempdir=$(mktemp)
 curl -o /tmp/go.tgz https://dl.google.com/go/go1.15.1.linux-amd64.tar.gz &&
-    tar -C $HOME -xzf /tmp/go.tgz &&
+    tar -C tempdir -xzf /tmp/go.tgz &&
     rm /tmp/go.tgz &&
-    export PATH=$HOME/go/bin:$PATH
+    export PATH=$tempdir/go/bin:$PATH
 
 go version
 go env

--- a/internal/kokoro/synth/synth.sh
+++ b/internal/kokoro/synth/synth.sh
@@ -9,11 +9,10 @@ set -e -x
 cd $(dirname $0)/../../..
 
 # Install Go 1.15
-rm -rf /usr/local/go
 curl -o /tmp/go.tgz https://dl.google.com/go/go1.15.1.linux-amd64.tar.gz &&
-    tar -C /usr/local -xzf /tmp/go.tgz &&
+    tar -C $HOME -xzf /tmp/go.tgz &&
     rm /tmp/go.tgz &&
-    export PATH=$PATH:/usr/local/go/bin
+    export PATH=$HOME/go/bin:$PATH
 
 go version
 go env


### PR DESCRIPTION
Unable to remove currently installed verision in this environment.
Instead, install in user home and add that to PATH.