### PR TITLE
chore(internal/kokoro): set GOROOT for synth

### DIFF
--- a/internal/kokoro/synth/synth.sh
+++ b/internal/kokoro/synth/synth.sh
@@ -13,7 +13,8 @@ tempdir=$(mktemp -d)
 curl -o /tmp/go.tgz https://dl.google.com/go/go1.15.1.linux-amd64.tar.gz &&
     tar -C $tempdir -xzf /tmp/go.tgz &&
     rm /tmp/go.tgz &&
-    export PATH=$tempdir/go/bin:$PATH
+    export PATH=$tempdir/go/bin:$PATH &&
+    export GOROOT=$tempdir/go
 
 go version
 go env


### PR DESCRIPTION
It seems like the build environment has GOROOT explicitly set to
`/usr/local/go`. `go build` returns the following compiler error:

compile: version "go1.12" does not match go tool version "go1.15.1"