### PR TITLE
chore(.github): add auto-approve bot to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owner for all directories not owned by others
-* @googleapis/yoshi-go-admins
+* @googleapis/yoshi-go-admins @yoshi-approver


### PR DESCRIPTION
This is needed so that the stamp it gives counts as having a
CODEOWNER review the change.