### PR TITLE
feat(oauth2): add AccessToken support for UserinfoGetCall

### DIFF
--- a/oauth2/v1/oauth2-gen.go
+++ b/oauth2/v1/oauth2-gen.go
@@ -466,6 +466,13 @@ func (r *UserinfoService) Get() *UserinfoGetCall {
 	return c
 }
 
+// AccessToken sets the optional parameter "access_token": The oauth2
+// access token
+func (c *UserinfoGetCall) AccessToken(accessToken string) *UserinfoGetCall {
+	c.urlParams_.Set("access_token", accessToken)
+	return c
+}
+
 // Fields allows partial responses to be retrieved. See
 // https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
 // for more information.

--- a/oauth2/v2/oauth2-gen.go
+++ b/oauth2/v2/oauth2-gen.go
@@ -445,6 +445,12 @@ func (r *UserinfoService) Get() *UserinfoGetCall {
 	return c
 }
 
+// AccessToken sets the optional parameter "access_token":
+func (c *UserinfoGetCall) AccessToken(accessToken string) *UserinfoGetCall {
+	c.urlParams_.Set("access_token", accessToken)
+	return c
+}
+
 // Fields allows partial responses to be retrieved. See
 // https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
 // for more information.


### PR DESCRIPTION
This PR suggests to extend the UserinfoGetCall with an AccessToken function which enables the user to request the Userinfo by providing the AccessToken as part of the query parameters.