### PR TITLE
chore: try to use correct version of Go

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,5 +9,10 @@
     ],
     "commitMessagePrefix": "chore(all): ",
     "commitMessageAction": "update",
-    "groupName": "all"
+    "groupName": "all",
+    "force": {
+      "constraints": {
+        "go": "1.16"
+      }
+    }
 }


### PR DESCRIPTION
Currently the tidying on the renovate PRs is never correct as we expect
it to be tidied to 1.16 standards. According to 
https://github.com/renovatebot/renovate/issues/6213 this should make
sure we are using version 1.16