### PR TITLE
fix(transport): increase ReadIdleTimeout

### DIFF
--- a/transport/http/configure_http2_go116.go
+++ b/transport/http/configure_http2_go116.go
@@ -20,6 +20,6 @@ import (
 func configureHTTP2(trans *http.Transport) {
 	http2Trans, err := http2.ConfigureTransports(trans)
 	if err == nil {
-		http2Trans.ReadIdleTimeout = time.Second * 15
+		http2Trans.ReadIdleTimeout = time.Second * 31
 	}
 }


### PR DESCRIPTION
Increase this value to comply with CFE rate limit on pings.

Closes googleapis/google-cloud-go#4121