### PR TITLE
fix(transport): Perform mtls endpoint switching with custom http client

### DIFF
--- a/transport/internal/dca/dca.go
+++ b/transport/internal/dca/dca.go
@@ -68,8 +68,6 @@ func GetClientCertificateSourceAndEndpoint(settings *internal.DialSettings) (cer
 func getClientCertificateSource(settings *internal.DialSettings) (cert.Source, error) {
 	if !isClientCertificateEnabled() {
 		return nil, nil
-	} else if settings.HTTPClient != nil {
-		return nil, nil // HTTPClient is incompatible with ClientCertificateSource
 	} else if settings.ClientCertSource != nil {
 		return settings.ClientCertSource, nil
 	} else {


### PR DESCRIPTION
The terraform CLI requires this change in order to support mTLS.

For existing users that provide custom http clients today, this change is invisible since it is gated by the mTLS environment variable.