### PR TITLE
fix(internal): fix self-signed detection with scopes

### DIFF
--- a/internal/creds.go
+++ b/internal/creds.go
@@ -99,7 +99,7 @@ func credentialsFromJSON(ctx context.Context, data []byte, ds *DialSettings) (*g
 }
 
 func isSelfSignedJWTFlow(data []byte, ds *DialSettings) (bool, error) {
-	if ((ds.EnableJwtWithScope && len(ds.GetScopes()) > 0) || ds.HasCustomAudience()) &&
+	if (ds.EnableJwtWithScope || ds.HasCustomAudience()) &&
 		ds.ImpersonationConfig == nil {
 		// Check if JSON is a service account and if so create a self-signed JWT.
 		var f struct {

--- a/internal/creds.go
+++ b/internal/creds.go
@@ -99,7 +99,7 @@ func credentialsFromJSON(ctx context.Context, data []byte, ds *DialSettings) (*g
 }
 
 func isSelfSignedJWTFlow(data []byte, ds *DialSettings) (bool, error) {
-	if (ds.EnableJwtWithScope || ds.HasCustomAudience() || len(ds.GetScopes()) == 0) &&
+	if ((ds.EnableJwtWithScope && len(ds.GetScopes()) > 0) || ds.HasCustomAudience()) &&
 		ds.ImpersonationConfig == nil {
 		// Check if JSON is a service account and if so create a self-signed JWT.
 		var f struct {


### PR DESCRIPTION
Removed the requirement on length of scopes passed. Checking the EnableJwtWithScope internal option should be sufficient since it will only be passed with our generated clients that will always include at least the platform scope and a default audience. 
Fixes: #1092