### PR TITLE
improved link for ChromeosdevicesListCall.Query()

### DIFF
--- a/admin/directory/v1/admin-api.json
+++ b/admin/directory/v1/admin-api.json
@@ -450,7 +450,7 @@
               "type": "string"
             },
             "query": {
-              "description": "Search string in the format given at http://support.google.com/chromeos/a/bin/answer.py?answer=1698333",
+              "description": "Search string in the format given at https://developers.google.com/admin-sdk/directory/v1/guides/manage-chrome-devices",
               "location": "query",
               "type": "string"
             },


### PR DESCRIPTION
The current [link](https://support.google.com/chrome/a/answer/1698333) doesn't actually seem to provide examples of queries but https://developers.google.com/admin-sdk/directory/v1/guides/manage-chrome-devices does.