### PR TITLE
Change Active data type to pointer boolean

### DIFF
--- a/analytics/v3/analytics-gen.go
+++ b/analytics/v3/analytics-gen.go
@@ -1326,7 +1326,7 @@ type CustomDimension struct {
 	AccountId string `json:"accountId,omitempty"`
 
 	// Active: Boolean indicating whether the custom dimension is active.
-	Active bool `json:"active,omitempty"`
+	Active *bool `json:"active,omitempty"`
 
 	// Created: Time the custom dimension was created.
 	Created string `json:"created,omitempty"`


### PR DESCRIPTION
Because golang didnt have null value, if a boolean variable's value is `false` it will be considered as `null` instead.
This could be quite problematic when someone wants to change or create a custom dimension with Inactive status because the `Active` field will instead be considered as an empty field an could the could cause an error.

To fix this, Active field will use pointer boolean instead so false value wouldn't be identified as `null`