### PR TITLE
docs: corrects daysInCycle description & documents only accepted option

### DIFF
--- a/compute/v0.alpha/compute-api.json
+++ b/compute/v0.alpha/compute-api.json
@@ -64424,7 +64424,7 @@
       "id": "ResourcePolicyDailyCycle",
       "properties": {
         "daysInCycle": {
-          "description": "Defines a schedule with units measured in months. The value determines how many months pass between the start of each cycle.",
+          "description": "Defines a schedule with units measured in days. The value determines how many days pass between the start of each cycle. The only supported value is 1.",
           "format": "int32",
           "type": "integer"
         },

--- a/compute/v0.beta/compute-api.json
+++ b/compute/v0.beta/compute-api.json
@@ -55437,7 +55437,7 @@
       "id": "ResourcePolicyDailyCycle",
       "properties": {
         "daysInCycle": {
-          "description": "Defines a schedule with units measured in months. The value determines how many months pass between the start of each cycle.",
+          "description": "Defines a schedule with units measured in days. The value determines how many days pass between the start of each cycle. The only supported value is 1.",
           "format": "int32",
           "type": "integer"
         },

--- a/compute/v1/compute-api.json
+++ b/compute/v1/compute-api.json
@@ -50026,7 +50026,7 @@
       "id": "ResourcePolicyDailyCycle",
       "properties": {
         "daysInCycle": {
-          "description": "Defines a schedule with units measured in months. The value determines how many months pass between the start of each cycle.",
+          "description": "Defines a schedule with units measured in days. The value determines how many days pass between the start of each cycle. The only supported value is 1.",
           "format": "int32",
           "type": "integer"
         },


### PR DESCRIPTION
fixes #1177 

There are also issues with the associated `compute-gen.go` files (including stating that they format is int64!) but there are instructions not to edit those files. 

I have changes to those files staged and can be added if needed. 