### PR TITLE
fix(dial): add nil checker

### DIFF
--- a/transport/http/dial.go
+++ b/transport/http/dial.go
@@ -102,7 +102,9 @@ func newTransport(ctx context.Context, base http.RoundTripper, settings *interna
 func newSettings(opts []option.ClientOption) (*internal.DialSettings, error) {
 	var o internal.DialSettings
 	for _, opt := range opts {
-		opt.Apply(&o)
+		if opt != nil {
+			opt.Apply(&o)
+		}
 	}
 	if err := o.Validate(); err != nil {
 		return nil, err


### PR DESCRIPTION
When passing nil to option.ClientOption cause panic

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1045db1e4]

goroutine 1 [running]:
google.golang.org/api/transport/http.newSettings({0x14000624180, 0x2, 0x2})
        /Users/billy/go/pkg/mod/google.golang.org/api@v0.60.0/transport/http/dial.go:105 +0x104
google.golang.org/api/transport/http.NewClient({0x1051f3e70, 0x140001a4000}, {0x14000624180, 0x2, 0x2})
        /Users/billy/go/pkg/mod/google.golang.org/api@v0.60.0/transport/http/dial.go:32 +0x38
google.golang.org/api/transport.NewHTTPClient(...)
        /Users/billy/go/pkg/mod/google.golang.org/api@v0.60.0/transport/dial.go:22
firebase.google.com/go/v4/messaging.NewClient({0x1051f3e70, 0x140001a4000}, 0x1400016c620)
        /Users/billy/go/pkg/mod/firebase.google.com/go/v4@v4.6.1/messaging/messaging.go:865 +0x54
firebase.google.com/go/v4.(*App).Messaging(0x140005f4120, {0x1051f3e70, 0x140001a4000})
        /Users/billy/go/pkg/mod/firebase.google.com/go/v4@v4.6.1/firebase.go:128 +0x88
main.main()
        /Users/billy/engineering/endorsaja/zeus/main.go:151 +0xf18
exit status 2
```