### PR TITLE
fix(internal/gensupport): Make SendRequestWithRetry check for canceled contexts twice

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211210111614-af8b64212486
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
 	google.golang.org/grpc v1.40.1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211210111614-af8b64212486
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/appengine v1.6.7
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
 	google.golang.org/grpc v1.40.1

--- a/internal/gensupport/send.go
+++ b/internal/gensupport/send.go
@@ -99,8 +99,7 @@ func sendAndRetry(ctx context.Context, client *http.Client, req *http.Request, r
 		case <-time.After(pause):
 		}
 
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			// Check for context cancellation once more. If more than one case in a
 			// select is satisfied at the same time, Go will choose one arbitrarily.
 			// That can cause an operation to go through even if the context was
@@ -109,7 +108,6 @@ func sendAndRetry(ctx context.Context, client *http.Client, req *http.Request, r
 				err = ctx.Err()
 			}
 			return resp, err
-		default:
 		}
 
 		resp, err = client.Do(req.WithContext(ctx))

--- a/internal/gensupport/send_test.go
+++ b/internal/gensupport/send_test.go
@@ -6,9 +6,10 @@ package gensupport
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"testing"
+
+	"golang.org/x/xerrors"
 )
 
 func TestSendRequest(t *testing.T) {
@@ -34,7 +35,7 @@ func TestSendRequestWithRetry(t *testing.T) {
 type brokenRoundTripper struct{}
 
 func (t *brokenRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	return nil, errors.New("this should not happen")
+	return nil, xerrors.New("this should not happen")
 }
 
 func TestCanceledContextDoesNotPerformRequest(t *testing.T) {
@@ -45,8 +46,8 @@ func TestCanceledContextDoesNotPerformRequest(t *testing.T) {
 		req, _ := http.NewRequest("GET", "url", nil)
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		_, err := SendRequestWithRetry(ctx, &client, req)
-		if !errors.Is(err, context.Canceled) {
+		_, err := SendRequestWithRetry(ctx, &client, req, nil)
+		if !xerrors.Is(err, context.Canceled) {
 			t.Fatalf("got %v, want %v", err, context.Canceled)
 		}
 	}


### PR DESCRIPTION
This change makes it deterministic to call SendRequestWithRetry with a
canceled context. This is going to be useful because some Cloud APIs
rely on the context being canceled to prevent some operations from
proceeding, like
[`storage.(*ObjectHandle).NewWriter`](https://pkg.go.dev/cloud.google.com/go/storage#ObjectHandle.NewWriter).

Fixes: #1358