### PR TITLE
fix: Adding import references in examples/customsearch

### DIFF
--- a/examples/customsearch.go
+++ b/examples/customsearch.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"net/http"
 
-	"google.golang.org/api/customsearch/v1"
+	customsearch "google.golang.org/api/customsearch/v1"
 	"google.golang.org/api/googleapi/transport"
 )
 


### PR DESCRIPTION
fix: Adding import references in examples/customsearch

Missing alias for the `customsearch` import statement will cause its references to raise errors. This type of package reference is also found in every other example, with similar import statements (`{package}/{version}`)