### PR TITLE
feat(gensupport): per-chunk deadline configs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,4 @@ require (
 	google.golang.org/appengine v1.6.7
 	google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350
 	google.golang.org/grpc v1.40.1
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/googleapi/googleapi.go
+++ b/googleapi/googleapi.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"google.golang.org/api/internal/third_party/uritemplates"
 )
@@ -245,12 +246,30 @@ func ChunkSize(size int) MediaOption {
 	return chunkSizeOption(size)
 }
 
+type chunkRetryDeadlineOption time.Duration
+
+func (cd chunkRetryDeadlineOption) setOptions(o *MediaOptions) {
+	o.ChunkRetryDeadline = time.Duration(cd)
+}
+
+// ChunkRetryDeadline returns a MediaOption which sets a per-chunk retry
+// deadline. If a single chunk has been attempting to upload for longer than
+// this time and the request fails, it will no longer be retried, and the error
+// will be returned to the caller.
+// This is only applicable for files which are large enough to require
+// a multi-chunk resumable upload.
+// The default value is 32s.
+// To set a deadline on the entire upload, use context timeout or cancellation.
+func ChunkRetryDeadline(deadline time.Duration) MediaOption {
+	return chunkRetryDeadlineOption(deadline)
+}
+
 // MediaOptions stores options for customizing media upload.  It is not used by developers directly.
 type MediaOptions struct {
 	ContentType           string
 	ForceEmptyContentType bool
-
 	ChunkSize int
+	ChunkRetryDeadline time.Duration
 }
 
 // ProcessMediaOptions stores options from opts in a MediaOptions.

--- a/googleapi/googleapi.go
+++ b/googleapi/googleapi.go
@@ -268,8 +268,8 @@ func ChunkRetryDeadline(deadline time.Duration) MediaOption {
 type MediaOptions struct {
 	ContentType           string
 	ForceEmptyContentType bool
-	ChunkSize int
-	ChunkRetryDeadline time.Duration
+	ChunkSize             int
+	ChunkRetryDeadline    time.Duration
 }
 
 // ProcessMediaOptions stores options from opts in a MediaOptions.

--- a/internal/gensupport/media.go
+++ b/internal/gensupport/media.go
@@ -15,6 +15,7 @@ import (
 	"net/textproto"
 	"strings"
 	"sync"
+	"time"
 
 	"google.golang.org/api/googleapi"
 )
@@ -223,6 +224,7 @@ type MediaInfo struct {
 	mType           string
 	size            int64 // mediaSize, if known.  Used only for calls to progressUpdater_.
 	progressUpdater googleapi.ProgressUpdater
+	chunkRetryDeadline time.Duration
 }
 
 // NewInfoFromMedia should be invoked from the Media method of a call. It returns a
@@ -234,6 +236,7 @@ func NewInfoFromMedia(r io.Reader, options []googleapi.MediaOption) *MediaInfo {
 	if !opts.ForceEmptyContentType {
 		r, mi.mType = DetermineContentType(r, opts.ContentType)
 	}
+	mi.chunkRetryDeadline = opts.ChunkRetryDeadline
 	mi.media, mi.buffer, mi.singleChunk = PrepareUpload(r, opts.ChunkSize)
 	return mi
 }
@@ -356,6 +359,7 @@ func (mi *MediaInfo) ResumableUpload(locURI string) *ResumableUpload {
 				mi.progressUpdater(curr, mi.size)
 			}
 		},
+		ChunkRetryDeadline: mi.chunkRetryDeadline,
 	}
 }
 

--- a/internal/gensupport/media.go
+++ b/internal/gensupport/media.go
@@ -218,12 +218,12 @@ func PrepareUpload(media io.Reader, chunkSize int) (r io.Reader, mb *MediaBuffer
 // code only.
 type MediaInfo struct {
 	// At most one of Media and MediaBuffer will be set.
-	media           io.Reader
-	buffer          *MediaBuffer
-	singleChunk     bool
-	mType           string
-	size            int64 // mediaSize, if known.  Used only for calls to progressUpdater_.
-	progressUpdater googleapi.ProgressUpdater
+	media              io.Reader
+	buffer             *MediaBuffer
+	singleChunk        bool
+	mType              string
+	size               int64 // mediaSize, if known.  Used only for calls to progressUpdater_.
+	progressUpdater    googleapi.ProgressUpdater
 	chunkRetryDeadline time.Duration
 }
 

--- a/internal/gensupport/media_test.go
+++ b/internal/gensupport/media_test.go
@@ -156,7 +156,7 @@ func TestNewInfoFromMedia(t *testing.T) {
 		opts                                   []googleapi.MediaOption
 		wantType                               string
 		wantMedia, wantBuffer, wantSingleChunk bool
-		wantDeadline													 time.Duration
+		wantDeadline                           time.Duration
 	}{
 		{
 			desc:            "an empty reader results in a MediaBuffer with a single, empty chunk",
@@ -175,11 +175,11 @@ func TestNewInfoFromMedia(t *testing.T) {
 			wantSingleChunk: true,
 		},
 		{
-			desc: "ChunkRetryDeadline is observed",
+			desc:            "ChunkRetryDeadline is observed",
 			r:               new(bytes.Buffer),
 			opts:            []googleapi.MediaOption{googleapi.ChunkRetryDeadline(time.Second)},
 			wantType:        textType,
-			wantBuffer:       true,
+			wantBuffer:      true,
 			wantSingleChunk: true,
 			wantDeadline:    time.Second,
 		},
@@ -355,7 +355,7 @@ func TestResumableUpload(t *testing.T) {
 		chunkSize           int
 		wantUploadType      string
 		wantResumableUpload bool
-		chunkRetryDeadline time.Duration
+		chunkRetryDeadline  time.Duration
 	}{
 		{
 			desc:                "chunk size of zero: don't use a MediaBuffer; upload as a single chunk",
@@ -393,7 +393,7 @@ func TestResumableUpload(t *testing.T) {
 			chunkSize:           1,
 			wantUploadType:      "resumable",
 			wantResumableUpload: true,
-			chunkRetryDeadline: 1 * time.Second,
+			chunkRetryDeadline:  1 * time.Second,
 		},
 	} {
 		opts := []googleapi.MediaOption{googleapi.ChunkSize(test.chunkSize)}

--- a/internal/gensupport/resumable.go
+++ b/internal/gensupport/resumable.go
@@ -34,6 +34,10 @@ type ResumableUpload struct {
 
 	// Retry optionally configures retries for requests made against the upload.
 	Retry *RetryConfig
+
+	// ChunkRetryDeadline configures the per-chunk deadline after which no further
+	// retries should happen.
+	ChunkRetryDeadline time.Duration
 }
 
 // Progress returns the number of bytes uploaded at this point.
@@ -155,6 +159,14 @@ func (rx *ResumableUpload) Upload(ctx context.Context) (resp *http.Response, err
 	}
 	// Configure retryable error criteria.
 	errorFunc := rx.Retry.errorFunc()
+
+	// Configure per-chunk retry deadline.
+	var retryDeadline time.Duration
+	if rx.ChunkRetryDeadline != 0 {
+		retryDeadline = rx.ChunkRetryDeadline
+	} else {
+		retryDeadline = defaultRetryDeadline
+	}
 
 	// Send all chunks.
 	for {

--- a/internal/gensupport/resumable_test.go
+++ b/internal/gensupport/resumable_test.go
@@ -335,10 +335,10 @@ func TestRetry_EachChunkHasItsOwnRetryDeadline(t *testing.T) {
 	}
 
 	rx := &ResumableUpload{
-		Client:    &http.Client{Transport: tr},
-		Media:     NewMediaBuffer(media, chunkSize),
-		MediaType: "text/plain",
-		Callback:  func(int64) {},
+		Client:             &http.Client{Transport: tr},
+		Media:              NewMediaBuffer(media, chunkSize),
+		MediaType:          "text/plain",
+		Callback:           func(int64) {},
 		ChunkRetryDeadline: 5 * time.Second,
 	}
 

--- a/internal/gensupport/retry.go
+++ b/internal/gensupport/retry.go
@@ -20,8 +20,8 @@ type Backoff interface {
 
 // These are declared as global variables so that tests can overwrite them.
 var (
-	// Per-chunk deadline for resumable uploads.
-	retryDeadline = 32 * time.Second
+	// Default per-chunk deadline for resumable uploads.
+	defaultRetryDeadline = 32 * time.Second
 	// Default backoff timer.
 	backoff = func() Backoff {
 		return &gax.Backoff{Initial: 100 * time.Millisecond}


### PR DESCRIPTION
feat(gensupport): per-chunk deadline configs

Allow users to configure the per-chunk deadline for retries
that's used during resumable uploads.

Needs to be exposed via the manual layer for storage.
    
Fixes #685
