### PR TITLE
fix(googleapi): fill response headers in Error

### DIFF
--- a/googleapi/googleapi.go
+++ b/googleapi/googleapi.go
@@ -141,6 +141,7 @@ func CheckResponse(res *http.Response) error {
 				jerr.Error.Code = res.StatusCode
 			}
 			jerr.Error.Body = string(slurp)
+			jerr.Error.Header = res.Header
 			return jerr.Error
 		}
 	}

--- a/googleapi/googleapi_test.go
+++ b/googleapi/googleapi_test.go
@@ -298,6 +298,20 @@ Details:
   }
 ]`,
 	},
+	{
+		// Case: Confirm that response headers are propagated to the error.
+		&http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header: map[string][]string{"key1": {"value1"}, "key2": {"value2", "value3"}},
+		},
+		`{"error":{}}`,
+		&Error{
+			Code: http.StatusInternalServerError,
+			Body: `{"error":{}}`,
+			Header: map[string][]string{"key1": {"value1"}, "key2": {"value2", "value3"}},
+		},
+		`googleapi: got HTTP response code 500 with body: {"error":{}}`,
+	},
 }
 
 func TestCheckResponse(t *testing.T) {

--- a/googleapi/googleapi_test.go
+++ b/googleapi/googleapi_test.go
@@ -302,12 +302,12 @@ Details:
 		// Case: Confirm that response headers are propagated to the error.
 		&http.Response{
 			StatusCode: http.StatusInternalServerError,
-			Header: map[string][]string{"key1": {"value1"}, "key2": {"value2", "value3"}},
+			Header:     map[string][]string{"key1": {"value1"}, "key2": {"value2", "value3"}},
 		},
 		`{"error":{}}`,
 		&Error{
-			Code: http.StatusInternalServerError,
-			Body: `{"error":{}}`,
+			Code:   http.StatusInternalServerError,
+			Body:   `{"error":{}}`,
 			Header: map[string][]string{"key1": {"value1"}, "key2": {"value2", "value3"}},
 		},
 		`googleapi: got HTTP response code 500 with body: {"error":{}}`,


### PR DESCRIPTION
Currently googleapi.Error is not populating the Header field with
response headers. We found this to be true across multiple APIs.
This fix ensures that Header is filled in correctly, allowing
easier debugging by callers.