### PR TITLE
fix(gensupport): cover ChunkRetryDeadline edge case

### DIFF
--- a/internal/gensupport/resumable.go
+++ b/internal/gensupport/resumable.go
@@ -155,6 +155,12 @@ func (rx *ResumableUpload) Upload(ctx context.Context) (resp *http.Response, err
 			}
 			return nil, err
 		}
+		// This case is very unlikely but possible only if rx.ChunkRetryDeadline is
+		// set to a very small value, in which case no requests will be sent before
+		// the deadline. Return an error to avoid causing a panic.
+		if resp == nil {
+			return nil, fmt.Errorf("upload request to %v not sent, choose larger value for ChunkRetryDealine", rx.URI)
+		}
 		return resp, nil
 	}
 	// Configure retryable error criteria.


### PR DESCRIPTION
Fix an edge case that I noticed when testing a very small
ChunkRetryDeadline via the storage client. If the user
chooses a deadline too short to send a single request for the
chunk, we cause a failure so that resp and err are not
both nil.