### PR TITLE
feat(internal/gensupport): add net.ErrClosed to default retry

### DIFF
--- a/internal/gensupport/retry.go
+++ b/internal/gensupport/retry.go
@@ -5,7 +5,10 @@
 package gensupport
 
 import (
+	"errors"
 	"io"
+	"net"
+	"strings"
 	"time"
 
 	"github.com/googleapis/gax-go/v2"
@@ -65,6 +68,14 @@ func shouldRetry(status int, err error) bool {
 			return true
 		}
 	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		if strings.Contains(opErr.Error(), "use of closed network connection") {
+			// TODO: check against net.ErrClosed (go 1.16+) instead of string
+			return true
+		}
+	}
+
 	// If Go 1.13 error unwrapping is available, use this to examine wrapped
 	// errors.
 	if err, ok := err.(interface{ Unwrap() error }); ok {


### PR DESCRIPTION
Fixes googleapis/google-cloud-go/issues/5704