### PR TITLE
docs: removed stale comment

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -145,8 +145,6 @@ func (w withGRPCDialOption) Apply(o *internal.DialSettings) {
 
 // WithGRPCConnectionPool returns a ClientOption that creates a pool of gRPC
 // connections that requests will be balanced between.
-//
-// This is an EXPERIMENTAL API and may be changed or removed in the future.
 func WithGRPCConnectionPool(size int) ClientOption {
 	return withGRPCConnectionPool(size)
 }


### PR DESCRIPTION
A customer noticed this comment in the documentation and became concerned about future support. Since this comment & feature have been in the library for > 6 years, can we get rid of the comment?