### PR TITLE
feat(all): prefer using WithDefaultScope option internally

### DIFF
--- a/accessapproval/v1/accessapproval-gen.go
+++ b/accessapproval/v1/accessapproval-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/accesscontextmanager/v1/accesscontextmanager-gen.go
+++ b/accesscontextmanager/v1/accesscontextmanager-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/accesscontextmanager/v1beta/accesscontextmanager-gen.go
+++ b/accesscontextmanager/v1beta/accesscontextmanager-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/adexchangebuyer2/v2beta1/adexchangebuyer2-gen.go
+++ b/adexchangebuyer2/v2beta1/adexchangebuyer2-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/adexchange.buyer",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/admin/datatransfer/v1/admin-gen.go
+++ b/admin/datatransfer/v1/admin-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/admin.datatransfer",
 		"https://www.googleapis.com/auth/admin.datatransfer.readonly",
 	)

--- a/admin/directory/v1/admin-gen.go
+++ b/admin/directory/v1/admin-gen.go
@@ -176,7 +176,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/admin.chrome.printers",
 		"https://www.googleapis.com/auth/admin.chrome.printers.readonly",
 		"https://www.googleapis.com/auth/admin.directory.customer",

--- a/admin/reports/v1/admin-gen.go
+++ b/admin/reports/v1/admin-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/admin.reports.audit.readonly",
 		"https://www.googleapis.com/auth/admin.reports.usage.readonly",
 	)

--- a/admob/v1/admob-gen.go
+++ b/admob/v1/admob-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/admob.readonly",
 		"https://www.googleapis.com/auth/admob.report",
 	)

--- a/admob/v1beta/admob-gen.go
+++ b/admob/v1beta/admob-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/admob.readonly",
 		"https://www.googleapis.com/auth/admob.report",
 	)

--- a/adsense/v2/adsense-gen.go
+++ b/adsense/v2/adsense-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/adsense",
 		"https://www.googleapis.com/auth/adsense.readonly",
 	)

--- a/adsensehost/v4.1/adsensehost-gen.go
+++ b/adsensehost/v4.1/adsensehost-gen.go
@@ -85,7 +85,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/adsensehost",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/alertcenter/v1beta1/alertcenter-gen.go
+++ b/alertcenter/v1beta1/alertcenter-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/apps.alerts",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/analytics/v3/analytics-gen.go
+++ b/analytics/v3/analytics-gen.go
@@ -108,7 +108,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/analytics",
 		"https://www.googleapis.com/auth/analytics.edit",
 		"https://www.googleapis.com/auth/analytics.manage.users",

--- a/analyticsadmin/v1alpha/analyticsadmin-gen.go
+++ b/analyticsadmin/v1alpha/analyticsadmin-gen.go
@@ -99,7 +99,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/analytics.edit",
 		"https://www.googleapis.com/auth/analytics.manage.users",
 		"https://www.googleapis.com/auth/analytics.manage.users.readonly",

--- a/analyticsdata/v1beta/analyticsdata-gen.go
+++ b/analyticsdata/v1beta/analyticsdata-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/analytics",
 		"https://www.googleapis.com/auth/analytics.readonly",
 	)

--- a/analyticsreporting/v4/analyticsreporting-gen.go
+++ b/analyticsreporting/v4/analyticsreporting-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/analytics",
 		"https://www.googleapis.com/auth/analytics.readonly",
 	)

--- a/androidenterprise/v1/androidenterprise-gen.go
+++ b/androidenterprise/v1/androidenterprise-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/androidenterprise",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/androidmanagement/v1/androidmanagement-gen.go
+++ b/androidmanagement/v1/androidmanagement-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/androidmanagement",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/androidpublisher/v3/androidpublisher-gen.go
+++ b/androidpublisher/v3/androidpublisher-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/androidpublisher",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/apigateway/v1/apigateway-gen.go
+++ b/apigateway/v1/apigateway-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/apigateway/v1beta/apigateway-gen.go
+++ b/apigateway/v1beta/apigateway-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/apigee/v1/apigee-gen.go
+++ b/apigee/v1/apigee-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/apikeys/v2/apikeys-gen.go
+++ b/apikeys/v2/apikeys-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 	)

--- a/appengine/v1/appengine-gen.go
+++ b/appengine/v1/appengine-gen.go
@@ -98,7 +98,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/appengine.admin",
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",

--- a/appengine/v1alpha/appengine-gen.go
+++ b/appengine/v1alpha/appengine-gen.go
@@ -98,7 +98,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/appengine.admin",
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",

--- a/appengine/v1beta/appengine-gen.go
+++ b/appengine/v1beta/appengine-gen.go
@@ -98,7 +98,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/appengine.admin",
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",

--- a/area120tables/v1alpha1/area120tables-gen.go
+++ b/area120tables/v1alpha1/area120tables-gen.go
@@ -106,7 +106,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/drive",
 		"https://www.googleapis.com/auth/drive.file",
 		"https://www.googleapis.com/auth/drive.readonly",

--- a/artifactregistry/v1/artifactregistry-gen.go
+++ b/artifactregistry/v1/artifactregistry-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 	)

--- a/artifactregistry/v1beta1/artifactregistry-gen.go
+++ b/artifactregistry/v1beta1/artifactregistry-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 	)

--- a/artifactregistry/v1beta2/artifactregistry-gen.go
+++ b/artifactregistry/v1beta2/artifactregistry-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 	)

--- a/assuredworkloads/v1/assuredworkloads-gen.go
+++ b/assuredworkloads/v1/assuredworkloads-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/authorizedbuyersmarketplace/v1/authorizedbuyersmarketplace-gen.go
+++ b/authorizedbuyersmarketplace/v1/authorizedbuyersmarketplace-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/authorized-buyers-marketplace",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/baremetalsolution/v1/baremetalsolution-gen.go
+++ b/baremetalsolution/v1/baremetalsolution-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/baremetalsolution/v2/baremetalsolution-gen.go
+++ b/baremetalsolution/v2/baremetalsolution-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/bigquery/v2/bigquery-gen.go
+++ b/bigquery/v2/bigquery-gen.go
@@ -115,7 +115,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/bigquery",
 		"https://www.googleapis.com/auth/bigquery.insertdata",
 		"https://www.googleapis.com/auth/cloud-platform",

--- a/bigqueryconnection/v1beta1/bigqueryconnection-gen.go
+++ b/bigqueryconnection/v1beta1/bigqueryconnection-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/bigquery",
 		"https://www.googleapis.com/auth/cloud-platform",
 	)

--- a/bigquerydatatransfer/v1/bigquerydatatransfer-gen.go
+++ b/bigquerydatatransfer/v1/bigquerydatatransfer-gen.go
@@ -99,7 +99,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/bigquery",
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",

--- a/bigqueryreservation/v1/bigqueryreservation-gen.go
+++ b/bigqueryreservation/v1/bigqueryreservation-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/bigquery",
 		"https://www.googleapis.com/auth/cloud-platform",
 	)

--- a/bigqueryreservation/v1beta1/bigqueryreservation-gen.go
+++ b/bigqueryreservation/v1beta1/bigqueryreservation-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/bigquery",
 		"https://www.googleapis.com/auth/cloud-platform",
 	)

--- a/bigtableadmin/v2/bigtableadmin-gen.go
+++ b/bigtableadmin/v2/bigtableadmin-gen.go
@@ -116,7 +116,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/bigtable.admin",
 		"https://www.googleapis.com/auth/bigtable.admin.cluster",
 		"https://www.googleapis.com/auth/bigtable.admin.instance",

--- a/billingbudgets/v1/billingbudgets-gen.go
+++ b/billingbudgets/v1/billingbudgets-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-billing",
 		"https://www.googleapis.com/auth/cloud-platform",
 	)

--- a/billingbudgets/v1beta1/billingbudgets-gen.go
+++ b/billingbudgets/v1beta1/billingbudgets-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-billing",
 		"https://www.googleapis.com/auth/cloud-platform",
 	)

--- a/binaryauthorization/v1/binaryauthorization-gen.go
+++ b/binaryauthorization/v1/binaryauthorization-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/binaryauthorization/v1beta1/binaryauthorization-gen.go
+++ b/binaryauthorization/v1beta1/binaryauthorization-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/blogger/v2/blogger-gen.go
+++ b/blogger/v2/blogger-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/blogger",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/blogger/v3/blogger-gen.go
+++ b/blogger/v3/blogger-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/blogger",
 		"https://www.googleapis.com/auth/blogger.readonly",
 	)

--- a/books/v1/books-gen.go
+++ b/books/v1/books-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/books",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/calendar/v3/calendar-gen.go
+++ b/calendar/v3/calendar-gen.go
@@ -103,7 +103,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/calendar",
 		"https://www.googleapis.com/auth/calendar.events",
 		"https://www.googleapis.com/auth/calendar.events.readonly",

--- a/certificatemanager/v1/certificatemanager-gen.go
+++ b/certificatemanager/v1/certificatemanager-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/chromemanagement/v1/chromemanagement-gen.go
+++ b/chromemanagement/v1/chromemanagement-gen.go
@@ -99,7 +99,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/chrome.management.appdetails.readonly",
 		"https://www.googleapis.com/auth/chrome.management.reports.readonly",
 		"https://www.googleapis.com/auth/chrome.management.telemetry.readonly",

--- a/chromepolicy/v1/chromepolicy-gen.go
+++ b/chromepolicy/v1/chromepolicy-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/chrome.management.policy",
 		"https://www.googleapis.com/auth/chrome.management.policy.readonly",
 	)

--- a/classroom/v1/classroom-gen.go
+++ b/classroom/v1/classroom-gen.go
@@ -160,7 +160,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/classroom.announcements",
 		"https://www.googleapis.com/auth/classroom.announcements.readonly",
 		"https://www.googleapis.com/auth/classroom.courses",

--- a/cloudasset/v1/cloudasset-gen.go
+++ b/cloudasset/v1/cloudasset-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudasset/v1beta1/cloudasset-gen.go
+++ b/cloudasset/v1beta1/cloudasset-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudasset/v1p1beta1/cloudasset-gen.go
+++ b/cloudasset/v1p1beta1/cloudasset-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudasset/v1p4beta1/cloudasset-gen.go
+++ b/cloudasset/v1p4beta1/cloudasset-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudasset/v1p5beta1/cloudasset-gen.go
+++ b/cloudasset/v1p5beta1/cloudasset-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudasset/v1p7beta1/cloudasset-gen.go
+++ b/cloudasset/v1p7beta1/cloudasset-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudbilling/v1/cloudbilling-gen.go
+++ b/cloudbilling/v1/cloudbilling-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-billing",
 		"https://www.googleapis.com/auth/cloud-billing.readonly",
 		"https://www.googleapis.com/auth/cloud-platform",

--- a/cloudbuild/v1/cloudbuild-gen.go
+++ b/cloudbuild/v1/cloudbuild-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudbuild/v1alpha1/cloudbuild-gen.go
+++ b/cloudbuild/v1alpha1/cloudbuild-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudbuild/v1alpha2/cloudbuild-gen.go
+++ b/cloudbuild/v1alpha2/cloudbuild-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudbuild/v1beta1/cloudbuild-gen.go
+++ b/cloudbuild/v1beta1/cloudbuild-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudchannel/v1/cloudchannel-gen.go
+++ b/cloudchannel/v1/cloudchannel-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/apps.order",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/clouddebugger/v2/clouddebugger-gen.go
+++ b/clouddebugger/v2/clouddebugger-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud_debugger",
 	)

--- a/clouddeploy/v1/clouddeploy-gen.go
+++ b/clouddeploy/v1/clouddeploy-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/clouderrorreporting/v1beta1/clouderrorreporting-gen.go
+++ b/clouderrorreporting/v1beta1/clouderrorreporting-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudfunctions/v1/cloudfunctions-gen.go
+++ b/cloudfunctions/v1/cloudfunctions-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudfunctions/v2alpha/cloudfunctions-gen.go
+++ b/cloudfunctions/v2alpha/cloudfunctions-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudfunctions/v2beta/cloudfunctions-gen.go
+++ b/cloudfunctions/v2beta/cloudfunctions-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudidentity/v1/cloudidentity-gen.go
+++ b/cloudidentity/v1/cloudidentity-gen.go
@@ -110,7 +110,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-identity.devices",
 		"https://www.googleapis.com/auth/cloud-identity.devices.lookup",
 		"https://www.googleapis.com/auth/cloud-identity.devices.readonly",

--- a/cloudidentity/v1beta1/cloudidentity-gen.go
+++ b/cloudidentity/v1beta1/cloudidentity-gen.go
@@ -110,7 +110,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-identity.devices",
 		"https://www.googleapis.com/auth/cloud-identity.devices.lookup",
 		"https://www.googleapis.com/auth/cloud-identity.devices.readonly",

--- a/cloudiot/v1/cloudiot-gen.go
+++ b/cloudiot/v1/cloudiot-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloudiot",
 	)

--- a/cloudkms/v1/cloudkms-gen.go
+++ b/cloudkms/v1/cloudkms-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloudkms",
 	)

--- a/cloudprofiler/v2/cloudprofiler-gen.go
+++ b/cloudprofiler/v2/cloudprofiler-gen.go
@@ -98,7 +98,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/monitoring",
 		"https://www.googleapis.com/auth/monitoring.write",

--- a/cloudresourcemanager/v1/cloudresourcemanager-gen.go
+++ b/cloudresourcemanager/v1/cloudresourcemanager-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 	)

--- a/cloudresourcemanager/v1beta1/cloudresourcemanager-gen.go
+++ b/cloudresourcemanager/v1beta1/cloudresourcemanager-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 	)

--- a/cloudresourcemanager/v2/cloudresourcemanager-gen.go
+++ b/cloudresourcemanager/v2/cloudresourcemanager-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 	)

--- a/cloudresourcemanager/v2beta1/cloudresourcemanager-gen.go
+++ b/cloudresourcemanager/v2beta1/cloudresourcemanager-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 	)

--- a/cloudresourcemanager/v3/cloudresourcemanager-gen.go
+++ b/cloudresourcemanager/v3/cloudresourcemanager-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 	)

--- a/cloudscheduler/v1/cloudscheduler-gen.go
+++ b/cloudscheduler/v1/cloudscheduler-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudscheduler/v1beta1/cloudscheduler-gen.go
+++ b/cloudscheduler/v1beta1/cloudscheduler-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudsearch/v1/cloudsearch-gen.go
+++ b/cloudsearch/v1/cloudsearch-gen.go
@@ -114,7 +114,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud_search",
 		"https://www.googleapis.com/auth/cloud_search.debug",
 		"https://www.googleapis.com/auth/cloud_search.indexing",

--- a/cloudshell/v1/cloudshell-gen.go
+++ b/cloudshell/v1/cloudshell-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudsupport/v2beta/cloudsupport-gen.go
+++ b/cloudsupport/v2beta/cloudsupport-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudtasks/v2/cloudtasks-gen.go
+++ b/cloudtasks/v2/cloudtasks-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudtasks/v2beta2/cloudtasks-gen.go
+++ b/cloudtasks/v2beta2/cloudtasks-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudtasks/v2beta3/cloudtasks-gen.go
+++ b/cloudtasks/v2beta3/cloudtasks-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/cloudtrace/v1/cloudtrace-gen.go
+++ b/cloudtrace/v1/cloudtrace-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/trace.append",
 		"https://www.googleapis.com/auth/trace.readonly",

--- a/cloudtrace/v2/cloudtrace-gen.go
+++ b/cloudtrace/v2/cloudtrace-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/trace.append",
 	)

--- a/cloudtrace/v2beta1/cloudtrace-gen.go
+++ b/cloudtrace/v2beta1/cloudtrace-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/trace.append",
 		"https://www.googleapis.com/auth/trace.readonly",

--- a/composer/v1/composer-gen.go
+++ b/composer/v1/composer-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/composer/v1beta1/composer-gen.go
+++ b/composer/v1beta1/composer-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/connectors/v1/connectors-gen.go
+++ b/connectors/v1/connectors-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/contactcenterinsights/v1/contactcenterinsights-gen.go
+++ b/contactcenterinsights/v1/contactcenterinsights-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/container/v1/container-gen.go
+++ b/container/v1/container-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/container/v1beta1/container-gen.go
+++ b/container/v1beta1/container-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/containeranalysis/v1/containeranalysis-gen.go
+++ b/containeranalysis/v1/containeranalysis-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/containeranalysis/v1alpha1/containeranalysis-gen.go
+++ b/containeranalysis/v1alpha1/containeranalysis-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/containeranalysis/v1beta1/containeranalysis-gen.go
+++ b/containeranalysis/v1beta1/containeranalysis-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/content/v2.1/content-gen.go
+++ b/content/v2.1/content-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/content",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/content/v2/content-gen.go
+++ b/content/v2/content-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/content",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/datacatalog/v1/datacatalog-gen.go
+++ b/datacatalog/v1/datacatalog-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/datacatalog/v1beta1/datacatalog-gen.go
+++ b/datacatalog/v1beta1/datacatalog-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/dataflow/v1b3/dataflow-gen.go
+++ b/dataflow/v1b3/dataflow-gen.go
@@ -100,7 +100,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/compute",
 		"https://www.googleapis.com/auth/compute.readonly",

--- a/datafusion/v1/datafusion-gen.go
+++ b/datafusion/v1/datafusion-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/datafusion/v1beta1/datafusion-gen.go
+++ b/datafusion/v1beta1/datafusion-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/datalabeling/v1beta1/datalabeling-gen.go
+++ b/datalabeling/v1beta1/datalabeling-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/datamigration/v1/datamigration-gen.go
+++ b/datamigration/v1/datamigration-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/datamigration/v1beta1/datamigration-gen.go
+++ b/datamigration/v1beta1/datamigration-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/datapipelines/v1/datapipelines-gen.go
+++ b/datapipelines/v1/datapipelines-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/dataplex/v1/dataplex-gen.go
+++ b/dataplex/v1/dataplex-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/dataproc/v1/dataproc-gen.go
+++ b/dataproc/v1/dataproc-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/datastore/v1/datastore-gen.go
+++ b/datastore/v1/datastore-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/datastore",
 	)

--- a/datastore/v1beta1/datastore-gen.go
+++ b/datastore/v1beta1/datastore-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/datastore",
 	)

--- a/datastore/v1beta3/datastore-gen.go
+++ b/datastore/v1beta3/datastore-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/datastore",
 	)

--- a/datastream/v1/datastream-gen.go
+++ b/datastream/v1/datastream-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/datastream/v1alpha1/datastream-gen.go
+++ b/datastream/v1alpha1/datastream-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/deploymentmanager/v0.alpha/deploymentmanager-gen.go
+++ b/deploymentmanager/v0.alpha/deploymentmanager-gen.go
@@ -103,7 +103,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/ndev.cloudman",

--- a/deploymentmanager/v2/deploymentmanager-gen.go
+++ b/deploymentmanager/v2/deploymentmanager-gen.go
@@ -103,7 +103,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/ndev.cloudman",

--- a/deploymentmanager/v2beta/deploymentmanager-gen.go
+++ b/deploymentmanager/v2beta/deploymentmanager-gen.go
@@ -103,7 +103,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/ndev.cloudman",

--- a/dfareporting/v3.3/dfareporting-gen.go
+++ b/dfareporting/v3.3/dfareporting-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/ddmconversions",
 		"https://www.googleapis.com/auth/dfareporting",
 		"https://www.googleapis.com/auth/dfatrafficking",

--- a/dfareporting/v3.4/dfareporting-gen.go
+++ b/dfareporting/v3.4/dfareporting-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/ddmconversions",
 		"https://www.googleapis.com/auth/dfareporting",
 		"https://www.googleapis.com/auth/dfatrafficking",

--- a/dfareporting/v3.5/dfareporting-gen.go
+++ b/dfareporting/v3.5/dfareporting-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/ddmconversions",
 		"https://www.googleapis.com/auth/dfareporting",
 		"https://www.googleapis.com/auth/dfatrafficking",

--- a/dialogflow/v2/dialogflow-gen.go
+++ b/dialogflow/v2/dialogflow-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/dialogflow",
 	)

--- a/dialogflow/v2beta1/dialogflow-gen.go
+++ b/dialogflow/v2beta1/dialogflow-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/dialogflow",
 	)

--- a/dialogflow/v3/dialogflow-gen.go
+++ b/dialogflow/v3/dialogflow-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/dialogflow",
 	)

--- a/dialogflow/v3beta1/dialogflow-gen.go
+++ b/dialogflow/v3beta1/dialogflow-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/dialogflow",
 	)

--- a/displayvideo/v1/displayvideo-gen.go
+++ b/displayvideo/v1/displayvideo-gen.go
@@ -102,7 +102,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/display-video",
 		"https://www.googleapis.com/auth/display-video-mediaplanning",
 		"https://www.googleapis.com/auth/display-video-user-management",

--- a/dlp/v2/dlp-gen.go
+++ b/dlp/v2/dlp-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/dns/v1/dns-gen.go
+++ b/dns/v1/dns-gen.go
@@ -101,7 +101,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/ndev.clouddns.readonly",

--- a/dns/v1beta2/dns-gen.go
+++ b/dns/v1beta2/dns-gen.go
@@ -101,7 +101,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/ndev.clouddns.readonly",

--- a/dns/v2/dns-gen.go
+++ b/dns/v2/dns-gen.go
@@ -101,7 +101,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/ndev.clouddns.readonly",

--- a/docs/v1/docs-gen.go
+++ b/docs/v1/docs-gen.go
@@ -103,7 +103,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/documents",
 		"https://www.googleapis.com/auth/documents.readonly",
 		"https://www.googleapis.com/auth/drive",

--- a/documentai/v1/documentai-gen.go
+++ b/documentai/v1/documentai-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/documentai/v1beta2/documentai-gen.go
+++ b/documentai/v1beta2/documentai-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/documentai/v1beta3/documentai-gen.go
+++ b/documentai/v1beta3/documentai-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/domains/v1/domains-gen.go
+++ b/domains/v1/domains-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/domains/v1alpha2/domains-gen.go
+++ b/domains/v1alpha2/domains-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/domains/v1beta1/domains-gen.go
+++ b/domains/v1beta1/domains-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/doubleclickbidmanager/v1.1/doubleclickbidmanager-gen.go
+++ b/doubleclickbidmanager/v1.1/doubleclickbidmanager-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/doubleclickbidmanager",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/doubleclicksearch/v2/doubleclicksearch-gen.go
+++ b/doubleclicksearch/v2/doubleclicksearch-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/doubleclicksearch",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/drive/v2/drive-gen.go
+++ b/drive/v2/drive-gen.go
@@ -115,7 +115,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/drive",
 		"https://www.googleapis.com/auth/drive.appdata",
 		"https://www.googleapis.com/auth/drive.apps.readonly",

--- a/drive/v3/drive-gen.go
+++ b/drive/v3/drive-gen.go
@@ -112,7 +112,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/drive",
 		"https://www.googleapis.com/auth/drive.appdata",
 		"https://www.googleapis.com/auth/drive.file",

--- a/driveactivity/v2/driveactivity-gen.go
+++ b/driveactivity/v2/driveactivity-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/drive.activity",
 		"https://www.googleapis.com/auth/drive.activity.readonly",
 	)

--- a/essentialcontacts/v1/essentialcontacts-gen.go
+++ b/essentialcontacts/v1/essentialcontacts-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/eventarc/v1/eventarc-gen.go
+++ b/eventarc/v1/eventarc-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/eventarc/v1beta1/eventarc-gen.go
+++ b/eventarc/v1beta1/eventarc-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/factchecktools/v1alpha1/factchecktools-gen.go
+++ b/factchecktools/v1alpha1/factchecktools-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/userinfo.email",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/fcm/v1/fcm-gen.go
+++ b/fcm/v1/fcm-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/firebase.messaging",
 	)

--- a/fcmdata/v1beta1/fcmdata-gen.go
+++ b/fcmdata/v1beta1/fcmdata-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/file/v1/file-gen.go
+++ b/file/v1/file-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/file/v1beta1/file-gen.go
+++ b/file/v1beta1/file-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/firebase/v1beta1/firebase-gen.go
+++ b/firebase/v1beta1/firebase-gen.go
@@ -101,7 +101,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/firebase",

--- a/firebaseappcheck/v1beta/firebaseappcheck-gen.go
+++ b/firebaseappcheck/v1beta/firebaseappcheck-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/firebase",
 	)

--- a/firebasedatabase/v1beta/firebasedatabase-gen.go
+++ b/firebasedatabase/v1beta/firebasedatabase-gen.go
@@ -101,7 +101,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/firebase",

--- a/firebasedynamiclinks/v1/firebasedynamiclinks-gen.go
+++ b/firebasedynamiclinks/v1/firebasedynamiclinks-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/firebase",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/firebasehosting/v1beta1/firebasehosting-gen.go
+++ b/firebasehosting/v1beta1/firebasehosting-gen.go
@@ -101,7 +101,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/firebase",

--- a/firebaseml/v1/firebaseml-gen.go
+++ b/firebaseml/v1/firebaseml-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/firebaseml/v1beta2/firebaseml-gen.go
+++ b/firebaseml/v1beta2/firebaseml-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/firebaserules/v1/firebaserules-gen.go
+++ b/firebaserules/v1/firebaserules-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/firebase",
 		"https://www.googleapis.com/auth/firebase.readonly",

--- a/firebasestorage/v1beta/firebasestorage-gen.go
+++ b/firebasestorage/v1beta/firebasestorage-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/firebase",
 	)

--- a/firestore/v1/firestore-gen.go
+++ b/firestore/v1/firestore-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/datastore",
 	)

--- a/firestore/v1beta1/firestore-gen.go
+++ b/firestore/v1beta1/firestore-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/datastore",
 	)

--- a/firestore/v1beta2/firestore-gen.go
+++ b/firestore/v1beta2/firestore-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/datastore",
 	)

--- a/fitness/v1/fitness-gen.go
+++ b/fitness/v1/fitness-gen.go
@@ -167,7 +167,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/fitness.activity.read",
 		"https://www.googleapis.com/auth/fitness.activity.write",
 		"https://www.googleapis.com/auth/fitness.blood_glucose.read",

--- a/forms/v1/forms-gen.go
+++ b/forms/v1/forms-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/drive",
 		"https://www.googleapis.com/auth/drive.file",
 		"https://www.googleapis.com/auth/drive.readonly",

--- a/games/v1/games-gen.go
+++ b/games/v1/games-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/drive.appdata",
 		"https://www.googleapis.com/auth/games",
 	)

--- a/gamesconfiguration/v1configuration/gamesconfiguration-gen.go
+++ b/gamesconfiguration/v1configuration/gamesconfiguration-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/androidpublisher",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/gameservices/v1/gameservices-gen.go
+++ b/gameservices/v1/gameservices-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/gameservices/v1beta/gameservices-gen.go
+++ b/gameservices/v1beta/gameservices-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/gamesmanagement/v1management/gamesmanagement-gen.go
+++ b/gamesmanagement/v1management/gamesmanagement-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/games",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/genomics/v2alpha1/genomics-gen.go
+++ b/genomics/v2alpha1/genomics-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/genomics",
 	)

--- a/gkehub/v1/gkehub-gen.go
+++ b/gkehub/v1/gkehub-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/gkehub/v1alpha/gkehub-gen.go
+++ b/gkehub/v1alpha/gkehub-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/gkehub/v1alpha2/gkehub-gen.go
+++ b/gkehub/v1alpha2/gkehub-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/gkehub/v1beta/gkehub-gen.go
+++ b/gkehub/v1beta/gkehub-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/gkehub/v1beta1/gkehub-gen.go
+++ b/gkehub/v1beta1/gkehub-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/gkehub/v2alpha/gkehub-gen.go
+++ b/gkehub/v2alpha/gkehub-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/gmail/v1/gmail-gen.go
+++ b/gmail/v1/gmail-gen.go
@@ -131,7 +131,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://mail.google.com/",
 		"https://www.googleapis.com/auth/gmail.addons.current.action.compose",
 		"https://www.googleapis.com/auth/gmail.addons.current.message.action",

--- a/gmailpostmastertools/v1/gmailpostmastertools-gen.go
+++ b/gmailpostmastertools/v1/gmailpostmastertools-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/postmaster.readonly",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/gmailpostmastertools/v1beta1/gmailpostmastertools-gen.go
+++ b/gmailpostmastertools/v1beta1/gmailpostmastertools-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/postmaster.readonly",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -752,7 +752,7 @@ func (a *API) GenerateCode() ([]byte, error) {
 	pn("// NewService creates a new %s.", service)
 	pn("func NewService(ctx context.Context, opts ...option.ClientOption) (*%s, error) {", service)
 	if len(a.doc.Auth.OAuth2Scopes) != 0 {
-		pn("scopesOption := option.WithScopes(")
+		pn("scopesOption := internaloption.WithDefaultScopes(")
 		for _, scope := range a.doc.Auth.OAuth2Scopes {
 			pn("%q,", scope.ID)
 		}

--- a/google-api-go-generator/testdata/any.want
+++ b/google-api-go-generator/testdata/any.want
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/google-api-go-generator/testdata/blogger-3.want
+++ b/google-api-go-generator/testdata/blogger-3.want
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/blogger",
 		"https://www.googleapis.com/auth/blogger.readonly",
 	)

--- a/google-api-go-generator/testdata/http-body.want
+++ b/google-api-go-generator/testdata/http-body.want
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/google-api-go-generator/testdata/json-body.want
+++ b/google-api-go-generator/testdata/json-body.want
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/google-api-go-generator/testdata/quotednum.want
+++ b/google-api-go-generator/testdata/quotednum.want
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/adexchange.buyer",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/google-api-go-generator/testdata/resource-named-service.want
+++ b/google-api-go-generator/testdata/resource-named-service.want
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/groupsmigration/v1/groupsmigration-gen.go
+++ b/groupsmigration/v1/groupsmigration-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/apps.groups.migration",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/groupssettings/v1/groupssettings-gen.go
+++ b/groupssettings/v1/groupssettings-gen.go
@@ -85,7 +85,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/apps.groups.settings",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/healthcare/v1/healthcare-gen.go
+++ b/healthcare/v1/healthcare-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/healthcare/v1beta1/healthcare-gen.go
+++ b/healthcare/v1beta1/healthcare-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/homegraph/v1/homegraph-gen.go
+++ b/homegraph/v1/homegraph-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/homegraph",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/iam/v1/iam-gen.go
+++ b/iam/v1/iam-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/iamcredentials/v1/iamcredentials-gen.go
+++ b/iamcredentials/v1/iamcredentials-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/iap/v1/iap-gen.go
+++ b/iap/v1/iap-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/iap/v1beta1/iap-gen.go
+++ b/iap/v1beta1/iap-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/identitytoolkit/v3/identitytoolkit-gen.go
+++ b/identitytoolkit/v3/identitytoolkit-gen.go
@@ -92,7 +92,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/firebase",
 	)

--- a/ids/v1/ids-gen.go
+++ b/ids/v1/ids-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/indexing/v3/indexing-gen.go
+++ b/indexing/v3/indexing-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/indexing",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/jobs/v3/jobs-gen.go
+++ b/jobs/v3/jobs-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/jobs",
 	)

--- a/jobs/v3p1beta1/jobs-gen.go
+++ b/jobs/v3p1beta1/jobs-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/jobs",
 	)

--- a/jobs/v4/jobs-gen.go
+++ b/jobs/v4/jobs-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/jobs",
 	)

--- a/keep/v1/keep-gen.go
+++ b/keep/v1/keep-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/keep",
 		"https://www.googleapis.com/auth/keep.readonly",
 	)

--- a/language/v1/language-gen.go
+++ b/language/v1/language-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-language",
 		"https://www.googleapis.com/auth/cloud-platform",
 	)

--- a/language/v1beta1/language-gen.go
+++ b/language/v1beta1/language-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-language",
 		"https://www.googleapis.com/auth/cloud-platform",
 	)

--- a/language/v1beta2/language-gen.go
+++ b/language/v1beta2/language-gen.go
@@ -97,7 +97,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-language",
 		"https://www.googleapis.com/auth/cloud-platform",
 	)

--- a/libraryagent/v1/libraryagent-gen.go
+++ b/libraryagent/v1/libraryagent-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/licensing/v1/licensing-gen.go
+++ b/licensing/v1/licensing-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/apps.licensing",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/lifesciences/v2beta/lifesciences-gen.go
+++ b/lifesciences/v2beta/lifesciences-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/localservices/v1/localservices-gen.go
+++ b/localservices/v1/localservices-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/adwords",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/logging/v2/logging-gen.go
+++ b/logging/v2/logging-gen.go
@@ -106,7 +106,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/logging.admin",

--- a/managedidentities/v1/managedidentities-gen.go
+++ b/managedidentities/v1/managedidentities-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/managedidentities/v1alpha1/managedidentities-gen.go
+++ b/managedidentities/v1alpha1/managedidentities-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/managedidentities/v1beta1/managedidentities-gen.go
+++ b/managedidentities/v1beta1/managedidentities-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/manufacturers/v1/manufacturers-gen.go
+++ b/manufacturers/v1/manufacturers-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/manufacturercenter",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/memcache/v1/memcache-gen.go
+++ b/memcache/v1/memcache-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/memcache/v1beta2/memcache-gen.go
+++ b/memcache/v1beta2/memcache-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/metastore/v1alpha/metastore-gen.go
+++ b/metastore/v1alpha/metastore-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/metastore/v1beta/metastore-gen.go
+++ b/metastore/v1beta/metastore-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/ml/v1/ml-gen.go
+++ b/ml/v1/ml-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 	)

--- a/monitoring/v1/monitoring-gen.go
+++ b/monitoring/v1/monitoring-gen.go
@@ -102,7 +102,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/monitoring",
 		"https://www.googleapis.com/auth/monitoring.read",

--- a/monitoring/v3/monitoring-gen.go
+++ b/monitoring/v3/monitoring-gen.go
@@ -104,7 +104,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/monitoring",
 		"https://www.googleapis.com/auth/monitoring.read",

--- a/networkconnectivity/v1/networkconnectivity-gen.go
+++ b/networkconnectivity/v1/networkconnectivity-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/networkconnectivity/v1alpha1/networkconnectivity-gen.go
+++ b/networkconnectivity/v1alpha1/networkconnectivity-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/networkmanagement/v1/networkmanagement-gen.go
+++ b/networkmanagement/v1/networkmanagement-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/networkmanagement/v1beta1/networkmanagement-gen.go
+++ b/networkmanagement/v1beta1/networkmanagement-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/networksecurity/v1/networksecurity-gen.go
+++ b/networksecurity/v1/networksecurity-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/networksecurity/v1beta1/networksecurity-gen.go
+++ b/networksecurity/v1beta1/networksecurity-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/networkservices/v1/networkservices-gen.go
+++ b/networkservices/v1/networkservices-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/networkservices/v1beta1/networkservices-gen.go
+++ b/networkservices/v1beta1/networkservices-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/notebooks/v1/notebooks-gen.go
+++ b/notebooks/v1/notebooks-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/oauth2/v2/oauth2-gen.go
+++ b/oauth2/v2/oauth2-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/userinfo.email",
 		"https://www.googleapis.com/auth/userinfo.profile",
 		"openid",

--- a/ondemandscanning/v1/ondemandscanning-gen.go
+++ b/ondemandscanning/v1/ondemandscanning-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/ondemandscanning/v1beta1/ondemandscanning-gen.go
+++ b/ondemandscanning/v1beta1/ondemandscanning-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/orgpolicy/v2/orgpolicy-gen.go
+++ b/orgpolicy/v2/orgpolicy-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/osconfig/v1/osconfig-gen.go
+++ b/osconfig/v1/osconfig-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/osconfig/v1alpha/osconfig-gen.go
+++ b/osconfig/v1alpha/osconfig-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/osconfig/v1beta/osconfig-gen.go
+++ b/osconfig/v1beta/osconfig-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/oslogin/v1/oslogin-gen.go
+++ b/oslogin/v1/oslogin-gen.go
@@ -103,7 +103,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/compute",

--- a/oslogin/v1alpha/oslogin-gen.go
+++ b/oslogin/v1alpha/oslogin-gen.go
@@ -103,7 +103,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/compute",

--- a/oslogin/v1beta/oslogin-gen.go
+++ b/oslogin/v1beta/oslogin-gen.go
@@ -103,7 +103,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/compute",

--- a/pagespeedonline/v5/pagespeedonline-gen.go
+++ b/pagespeedonline/v5/pagespeedonline-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"openid",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/people/v1/people-gen.go
+++ b/people/v1/people-gen.go
@@ -125,7 +125,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/contacts",
 		"https://www.googleapis.com/auth/contacts.other.readonly",
 		"https://www.googleapis.com/auth/contacts.readonly",

--- a/playcustomapp/v1/playcustomapp-gen.go
+++ b/playcustomapp/v1/playcustomapp-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/androidpublisher",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/policyanalyzer/v1/policyanalyzer-gen.go
+++ b/policyanalyzer/v1/policyanalyzer-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/policyanalyzer/v1beta1/policyanalyzer-gen.go
+++ b/policyanalyzer/v1beta1/policyanalyzer-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/policysimulator/v1/policysimulator-gen.go
+++ b/policysimulator/v1/policysimulator-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/policysimulator/v1beta1/policysimulator-gen.go
+++ b/policysimulator/v1beta1/policysimulator-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/policytroubleshooter/v1/policytroubleshooter-gen.go
+++ b/policytroubleshooter/v1/policytroubleshooter-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/policytroubleshooter/v1beta/policytroubleshooter-gen.go
+++ b/policytroubleshooter/v1beta/policytroubleshooter-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/privateca/v1/privateca-gen.go
+++ b/privateca/v1/privateca-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/privateca/v1beta1/privateca-gen.go
+++ b/privateca/v1beta1/privateca-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/prod_tt_sasportal/v1alpha1/prod_tt_sasportal-gen.go
+++ b/prod_tt_sasportal/v1alpha1/prod_tt_sasportal-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/userinfo.email",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/pubsub/v1/pubsub-gen.go
+++ b/pubsub/v1/pubsub-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/pubsub",
 	)

--- a/pubsub/v1beta1a/pubsub-gen.go
+++ b/pubsub/v1beta1a/pubsub-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/pubsub",
 	)

--- a/pubsub/v1beta2/pubsub-gen.go
+++ b/pubsub/v1beta2/pubsub-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/pubsub",
 	)

--- a/pubsublite/v1/pubsublite-gen.go
+++ b/pubsublite/v1/pubsublite-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/realtimebidding/v1/realtimebidding-gen.go
+++ b/realtimebidding/v1/realtimebidding-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/realtime-bidding",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/realtimebidding/v1alpha/realtimebidding-gen.go
+++ b/realtimebidding/v1alpha/realtimebidding-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/realtime-bidding",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/recaptchaenterprise/v1/recaptchaenterprise-gen.go
+++ b/recaptchaenterprise/v1/recaptchaenterprise-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/recommendationengine/v1beta1/recommendationengine-gen.go
+++ b/recommendationengine/v1beta1/recommendationengine-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/recommender/v1/recommender-gen.go
+++ b/recommender/v1/recommender-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/recommender/v1beta1/recommender-gen.go
+++ b/recommender/v1beta1/recommender-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/redis/v1/redis-gen.go
+++ b/redis/v1/redis-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/redis/v1beta1/redis-gen.go
+++ b/redis/v1beta1/redis-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/reseller/v1/reseller-gen.go
+++ b/reseller/v1/reseller-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/apps.order",
 		"https://www.googleapis.com/auth/apps.order.readonly",
 	)

--- a/resourcesettings/v1/resourcesettings-gen.go
+++ b/resourcesettings/v1/resourcesettings-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/retail/v2/retail-gen.go
+++ b/retail/v2/retail-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/retail/v2alpha/retail-gen.go
+++ b/retail/v2alpha/retail-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/retail/v2beta/retail-gen.go
+++ b/retail/v2beta/retail-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/run/v1/run-gen.go
+++ b/run/v1/run-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/run/v1alpha1/run-gen.go
+++ b/run/v1alpha1/run-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/run/v2/run-gen.go
+++ b/run/v2/run-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/runtimeconfig/v1/runtimeconfig-gen.go
+++ b/runtimeconfig/v1/runtimeconfig-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloudruntimeconfig",
 	)

--- a/runtimeconfig/v1beta1/runtimeconfig-gen.go
+++ b/runtimeconfig/v1beta1/runtimeconfig-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloudruntimeconfig",
 	)

--- a/sasportal/v1alpha1/sasportal-gen.go
+++ b/sasportal/v1alpha1/sasportal-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/userinfo.email",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/script/v1/script-gen.go
+++ b/script/v1/script-gen.go
@@ -142,7 +142,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://mail.google.com/",
 		"https://www.google.com/calendar/feeds",
 		"https://www.google.com/m8/feeds",

--- a/searchconsole/v1/searchconsole-gen.go
+++ b/searchconsole/v1/searchconsole-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/webmasters",
 		"https://www.googleapis.com/auth/webmasters.readonly",
 	)

--- a/secretmanager/v1/secretmanager-gen.go
+++ b/secretmanager/v1/secretmanager-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/secretmanager/v1beta1/secretmanager-gen.go
+++ b/secretmanager/v1beta1/secretmanager-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/securitycenter/v1/securitycenter-gen.go
+++ b/securitycenter/v1/securitycenter-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/securitycenter/v1beta1/securitycenter-gen.go
+++ b/securitycenter/v1beta1/securitycenter-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/securitycenter/v1beta2/securitycenter-gen.go
+++ b/securitycenter/v1beta2/securitycenter-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/serviceconsumermanagement/v1/serviceconsumermanagement-gen.go
+++ b/serviceconsumermanagement/v1/serviceconsumermanagement-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/serviceconsumermanagement/v1beta1/serviceconsumermanagement-gen.go
+++ b/serviceconsumermanagement/v1beta1/serviceconsumermanagement-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/servicecontrol/v1/servicecontrol-gen.go
+++ b/servicecontrol/v1/servicecontrol-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/servicecontrol",
 	)

--- a/servicecontrol/v2/servicecontrol-gen.go
+++ b/servicecontrol/v2/servicecontrol-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/servicecontrol",
 	)

--- a/servicedirectory/v1/servicedirectory-gen.go
+++ b/servicedirectory/v1/servicedirectory-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/servicedirectory/v1beta1/servicedirectory-gen.go
+++ b/servicedirectory/v1beta1/servicedirectory-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/servicemanagement/v1/servicemanagement-gen.go
+++ b/servicemanagement/v1/servicemanagement-gen.go
@@ -101,7 +101,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/service.management",

--- a/servicenetworking/v1/servicenetworking-gen.go
+++ b/servicenetworking/v1/servicenetworking-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/service.management",
 	)

--- a/servicenetworking/v1beta/servicenetworking-gen.go
+++ b/servicenetworking/v1beta/servicenetworking-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/service.management",
 	)

--- a/serviceusage/v1/serviceusage-gen.go
+++ b/serviceusage/v1/serviceusage-gen.go
@@ -98,7 +98,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/service.management",

--- a/serviceusage/v1beta1/serviceusage-gen.go
+++ b/serviceusage/v1beta1/serviceusage-gen.go
@@ -98,7 +98,7 @@ const (
 
 // NewService creates a new APIService.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/service.management",

--- a/sheets/v4/sheets-gen.go
+++ b/sheets/v4/sheets-gen.go
@@ -103,7 +103,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/drive",
 		"https://www.googleapis.com/auth/drive.file",
 		"https://www.googleapis.com/auth/drive.readonly",

--- a/siteverification/v1/siteverification-gen.go
+++ b/siteverification/v1/siteverification-gen.go
@@ -92,7 +92,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/siteverification",
 		"https://www.googleapis.com/auth/siteverification.verify_only",
 	)

--- a/slides/v1/slides-gen.go
+++ b/slides/v1/slides-gen.go
@@ -109,7 +109,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/drive",
 		"https://www.googleapis.com/auth/drive.file",
 		"https://www.googleapis.com/auth/drive.readonly",

--- a/smartdevicemanagement/v1/smartdevicemanagement-gen.go
+++ b/smartdevicemanagement/v1/smartdevicemanagement-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/sdm.service",
 		"https://www.googleapis.com/auth/sdm.thermostat.service",
 	)

--- a/sourcerepo/v1/sourcerepo-gen.go
+++ b/sourcerepo/v1/sourcerepo-gen.go
@@ -100,7 +100,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/source.full_control",
 		"https://www.googleapis.com/auth/source.read_only",

--- a/spanner/v1/spanner-gen.go
+++ b/spanner/v1/spanner-gen.go
@@ -99,7 +99,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/spanner.admin",
 		"https://www.googleapis.com/auth/spanner.data",

--- a/speech/v1/speech-gen.go
+++ b/speech/v1/speech-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/speech/v1p1beta1/speech-gen.go
+++ b/speech/v1p1beta1/speech-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/speech/v2beta1/speech-gen.go
+++ b/speech/v2beta1/speech-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/sqladmin/v1/sqladmin-gen.go
+++ b/sqladmin/v1/sqladmin-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/sqlservice.admin",
 	)

--- a/sqladmin/v1beta4/sqladmin-gen.go
+++ b/sqladmin/v1beta4/sqladmin-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/sqlservice.admin",
 	)

--- a/storage/v1/storage-gen.go
+++ b/storage/v1/storage-gen.go
@@ -105,7 +105,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 		"https://www.googleapis.com/auth/devstorage.full_control",

--- a/storagetransfer/v1/storagetransfer-gen.go
+++ b/storagetransfer/v1/storagetransfer-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/streetviewpublish/v1/streetviewpublish-gen.go
+++ b/streetviewpublish/v1/streetviewpublish-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/streetviewpublish",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/tagmanager/v1/tagmanager-gen.go
+++ b/tagmanager/v1/tagmanager-gen.go
@@ -110,7 +110,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/tagmanager.delete.containers",
 		"https://www.googleapis.com/auth/tagmanager.edit.containers",
 		"https://www.googleapis.com/auth/tagmanager.edit.containerversions",

--- a/tagmanager/v2/tagmanager-gen.go
+++ b/tagmanager/v2/tagmanager-gen.go
@@ -110,7 +110,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/tagmanager.delete.containers",
 		"https://www.googleapis.com/auth/tagmanager.edit.containers",
 		"https://www.googleapis.com/auth/tagmanager.edit.containerversions",

--- a/tasks/v1/tasks-gen.go
+++ b/tasks/v1/tasks-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/tasks",
 		"https://www.googleapis.com/auth/tasks.readonly",
 	)

--- a/testing/v1/testing-gen.go
+++ b/testing/v1/testing-gen.go
@@ -95,7 +95,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-platform.read-only",
 	)

--- a/texttospeech/v1/texttospeech-gen.go
+++ b/texttospeech/v1/texttospeech-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/texttospeech/v1beta1/texttospeech-gen.go
+++ b/texttospeech/v1beta1/texttospeech-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/toolresults/v1beta3/toolresults-gen.go
+++ b/toolresults/v1beta3/toolresults-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/tpu/v1/tpu-gen.go
+++ b/tpu/v1/tpu-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/tpu/v1alpha1/tpu-gen.go
+++ b/tpu/v1alpha1/tpu-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/tpu/v2alpha1/tpu-gen.go
+++ b/tpu/v2alpha1/tpu-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/trafficdirector/v2/trafficdirector-gen.go
+++ b/trafficdirector/v2/trafficdirector-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/transcoder/v1/transcoder-gen.go
+++ b/transcoder/v1/transcoder-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/translate/v2/translate-gen.go
+++ b/translate/v2/translate-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-translation",
 	)

--- a/translate/v3/translate-gen.go
+++ b/translate/v3/translate-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-translation",
 	)

--- a/translate/v3beta1/translate-gen.go
+++ b/translate/v3beta1/translate-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-translation",
 	)

--- a/vault/v1/vault-gen.go
+++ b/vault/v1/vault-gen.go
@@ -93,7 +93,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/ediscovery",
 		"https://www.googleapis.com/auth/ediscovery.readonly",
 	)

--- a/verifiedaccess/v1/verifiedaccess-gen.go
+++ b/verifiedaccess/v1/verifiedaccess-gen.go
@@ -86,7 +86,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/verifiedaccess",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/videointelligence/v1/videointelligence-gen.go
+++ b/videointelligence/v1/videointelligence-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/videointelligence/v1beta2/videointelligence-gen.go
+++ b/videointelligence/v1beta2/videointelligence-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/videointelligence/v1p1beta1/videointelligence-gen.go
+++ b/videointelligence/v1p1beta1/videointelligence-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/videointelligence/v1p2beta1/videointelligence-gen.go
+++ b/videointelligence/v1p2beta1/videointelligence-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/videointelligence/v1p3beta1/videointelligence-gen.go
+++ b/videointelligence/v1p3beta1/videointelligence-gen.go
@@ -89,7 +89,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/vision/v1/vision-gen.go
+++ b/vision/v1/vision-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-vision",
 	)

--- a/vision/v1p1beta1/vision-gen.go
+++ b/vision/v1p1beta1/vision-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-vision",
 	)

--- a/vision/v1p2beta1/vision-gen.go
+++ b/vision/v1p2beta1/vision-gen.go
@@ -96,7 +96,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 		"https://www.googleapis.com/auth/cloud-vision",
 	)

--- a/vmmigration/v1/vmmigration-gen.go
+++ b/vmmigration/v1/vmmigration-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/vmmigration/v1alpha1/vmmigration-gen.go
+++ b/vmmigration/v1alpha1/vmmigration-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/webrisk/v1/webrisk-gen.go
+++ b/webrisk/v1/webrisk-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/websecurityscanner/v1/websecurityscanner-gen.go
+++ b/websecurityscanner/v1/websecurityscanner-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/websecurityscanner/v1alpha/websecurityscanner-gen.go
+++ b/websecurityscanner/v1alpha/websecurityscanner-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/websecurityscanner/v1beta/websecurityscanner-gen.go
+++ b/websecurityscanner/v1beta/websecurityscanner-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/workflowexecutions/v1/workflowexecutions-gen.go
+++ b/workflowexecutions/v1/workflowexecutions-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/workflowexecutions/v1beta/workflowexecutions-gen.go
+++ b/workflowexecutions/v1beta/workflowexecutions-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/workflows/v1/workflows-gen.go
+++ b/workflows/v1/workflows-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/workflows/v1beta/workflows-gen.go
+++ b/workflows/v1beta/workflows-gen.go
@@ -87,7 +87,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	// NOTE: prepend, so we don't override user-specified scopes.

--- a/youtube/v3/youtube-gen.go
+++ b/youtube/v3/youtube-gen.go
@@ -111,7 +111,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/youtube",
 		"https://www.googleapis.com/auth/youtube.channel-memberships.creator",
 		"https://www.googleapis.com/auth/youtube.force-ssl",

--- a/youtubeanalytics/v2/youtubeanalytics-gen.go
+++ b/youtubeanalytics/v2/youtubeanalytics-gen.go
@@ -103,7 +103,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/youtube",
 		"https://www.googleapis.com/auth/youtube.readonly",
 		"https://www.googleapis.com/auth/youtubepartner",

--- a/youtubereporting/v1/youtubereporting-gen.go
+++ b/youtubereporting/v1/youtubereporting-gen.go
@@ -94,7 +94,7 @@ const (
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
-	scopesOption := option.WithScopes(
+	scopesOption := internaloption.WithDefaultScopes(
 		"https://www.googleapis.com/auth/yt-analytics-monetary.readonly",
 		"https://www.googleapis.com/auth/yt-analytics.readonly",
 	)


### PR DESCRIPTION
Currently these clients don't allow users to specify an aud because
both aud and scopes may not be provided at the same time. By moving
internal logic to use WithDefaultScopes we allow more flexability
with these clients. Updated local cached file.

Internal issue: b/223898679