### PR TITLE
feat(google-api-go-generator): Change field PaymentState to pointer

### DIFF
--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -965,6 +965,7 @@ var pointerFields = []fieldName{
 	{api: "androidpublisher:v3", schema: "ProductPurchase", field: "PurchaseType"},
 	{api: "androidpublisher:v2", schema: "SubscriptionPurchase", field: "CancelReason"},
 	{api: "androidpublisher:v2", schema: "SubscriptionPurchase", field: "PaymentState"},
+	{api: "androidpublisher:v3", schema: "SubscriptionPurchase", field: "PaymentState"},
 	{api: "androidpublisher:v2", schema: "SubscriptionPurchase", field: "PurchaseType"},
 	{api: "androidpublisher:v3", schema: "SubscriptionPurchase", field: "PurchaseType"},
 	{api: "cloudmonitoring:v2beta2", schema: "Point", field: "BoolValue"},


### PR DESCRIPTION
Added field PaymentState of schema SubscriptionPurchase of the androidpublisher:v3 api to the list of pointerFields. This was done the same way as it was previously done for v2.

Fixes #727