### PR TITLE
docs(option): clarify behavior of WithScopes

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -82,6 +82,9 @@ func (w withEndpoint) Apply(o *internal.DialSettings) {
 
 // WithScopes returns a ClientOption that overrides the default OAuth2 scopes
 // to be used for a service.
+//
+// If both WithScopes and WithTokenSource are used, scope settings from the
+// token source will be used instead.
 func WithScopes(scope ...string) ClientOption {
 	return withScopes(scope)
 }


### PR DESCRIPTION
Clarify that when both WithScopes and WithTokenSource are used, the
scope settings will be taken from the token source and the WithScopes
option will be ignored.

Fixes #1644