### PR TITLE
feat(option): officially deprecate ImpersonateCredentials

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -308,9 +308,9 @@ func (w withClientCertSource) Apply(o *internal.DialSettings) {
 //
 // This is an EXPERIMENTAL API and may be changed or removed in the future.
 //
-// This option has been replaced by `impersonate` package:
+// Deprecated: This option has been replaced by `impersonate` package:
 // `google.golang.org/api/impersonate`. Please use the `impersonate` package
-// instead.
+// instead with the WithTokenSource option.
 func ImpersonateCredentials(target string, delegates ...string) ClientOption {
 	return impersonateServiceAccount{
 		target:    target,


### PR DESCRIPTION
This option has been soft deprecated for a long time now. Lets make
it official to help more users migrate.