### PR TITLE
feat(internal/gensupport): wrap retry failures with context and prev error

### DIFF
--- a/internal/gensupport/send.go
+++ b/internal/gensupport/send.go
@@ -64,7 +64,7 @@ func send(ctx context.Context, client *http.Client, req *http.Request) (*http.Re
 	if err != nil {
 		select {
 		case <-ctx.Done():
-			err = wrappedCallErr{ctx.Err(), err}
+			err = ctx.Err()
 		default:
 		}
 	}

--- a/internal/gensupport/send.go
+++ b/internal/gensupport/send.go
@@ -98,10 +98,11 @@ func sendAndRetry(ctx context.Context, client *http.Client, req *http.Request, r
 		case <-ctx.Done():
 			// If we got an error, and the context has been canceled,
 			// the context's error is probably more useful.
-			if err == nil {
-				err = ctx.Err()
+			retErr := ctx.Err()
+			if err != nil { // let's still return a previous error if any
+				retErr = fmt.Errorf("context error: %v. previous send error: %w", ctx.Err(), err)
 			}
-			return resp, err
+			return resp, retErr
 		case <-time.After(pause):
 		}
 

--- a/internal/gensupport/send.go
+++ b/internal/gensupport/send.go
@@ -117,8 +117,8 @@ func sendAndRetry(ctx context.Context, client *http.Client, req *http.Request, r
 	for {
 		select {
 		case <-ctx.Done():
-			// If we got an error, and the context has been canceled,
-			// the context's error is probably more useful.
+			// If we got an error and the context has been canceled, return an error acknowledging
+			// both the context cancelation and the service error.
 			if err != nil {
 				return resp, wrappedCallErr{ctx.Err(), err}
 			}


### PR DESCRIPTION
I have a use case in which my context is cancelling a `sendAndRetry()` operation, and the error being returned is the error returned by the Google API in the previous attempt of `sendAndRetry()` instead of `ctx.Err()`, which is misleading because I was investigating why the Google Storage Go library was giving up on a 503 error (which is not expected according to the retry/idempotency docs: https://cloud.google.com/storage/docs/retry-strategy).

closes: #1685