### PR TITLE
fix(transport/grpc): separate options for creds and certs

### DIFF
--- a/transport/grpc/dial.go
+++ b/transport/grpc/dial.go
@@ -129,7 +129,15 @@ func dial(ctx context.Context, insecure bool, o *internal.DialSettings) (*grpc.C
 	var grpcOpts []grpc.DialOption
 	if insecure {
 		grpcOpts = []grpc.DialOption{grpc.WithInsecure()}
-	} else if !o.NoAuth {
+	} else {
+		tlsConfig := &tls.Config{
+			GetClientCertificate: clientCertSource,
+		}
+		grpcOpts = []grpc.DialOption{
+			grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
+		}
+	}
+	if !o.NoAuth {
 		if o.APIKey != "" {
 			log.Print("API keys are not supported for gRPC APIs. Remove the WithAPIKey option from your client-creating call.")
 		}
@@ -142,8 +150,17 @@ func dial(ctx context.Context, insecure bool, o *internal.DialSettings) (*grpc.C
 			o.QuotaProject = internal.QuotaProjectFromCreds(creds)
 		}
 
+		grpcOpts = append(grpcOpts,
+			grpc.WithPerRPCCredentials(grpcTokenSource{
+				TokenSource:   oauth.TokenSource{creds.TokenSource},
+				quotaProject:  o.QuotaProject,
+				requestReason: o.RequestReason,
+			}),
+		)
+
 		// Attempt Direct Path:
 		if isDirectPathEnabled(endpoint, o) && isTokenSourceDirectPathCompatible(creds.TokenSource, o) && metadata.OnGCE() {
+			// Overwrite all of the previously specific DialOptions, DirectPath uses its own set of credentials and certificates.
 			grpcOpts = []grpc.DialOption{
 				grpc.WithCredentialsBundle(grpcgoogle.NewDefaultCredentialsWithOptions(grpcgoogle.DefaultCredentialsOptions{oauth.TokenSource{creds.TokenSource}}))}
 			if timeoutDialerOption != nil {
@@ -169,18 +186,6 @@ func dial(ctx context.Context, insecure bool, o *internal.DialSettings) (*grpc.C
 					grpc.WithDefaultServiceConfig(`{"loadBalancingConfig":[{"grpclb":{"childPolicy":[{"pick_first":{}}]}}]}`))
 			}
 			// TODO(cbro): add support for system parameters (quota project, request reason) via chained interceptor.
-		} else {
-			tlsConfig := &tls.Config{
-				GetClientCertificate: clientCertSource,
-			}
-			grpcOpts = []grpc.DialOption{
-				grpc.WithPerRPCCredentials(grpcTokenSource{
-					TokenSource:   oauth.TokenSource{creds.TokenSource},
-					quotaProject:  o.QuotaProject,
-					requestReason: o.RequestReason,
-				}),
-				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-			}
 		}
 	}
 


### PR DESCRIPTION
For **gRPC**, this separates the logic for _credential_ dial options (associated with the `WithoutAuthentication` option) from the _connection-level encryption_ dial options (associated with the `WithInsecure` option OR using `DialInsecure`). This allows a _secure_ connection to be dialed _without_ credentials.

Previously, using `WithoutAuthentication` alone (i.e. without `WithInsecure` or `grpc.WithTransportCredentials(credentials.NewTLS(nil))`, and while using `Dial`) would result in attempting to dial a secure connection but without any credentials **or** TLS config, resulting in an error. For example, the following code returns an error:
```go
c, err := grpc.Dial(context.Background(),
  option.WithEndpoint("storage.googleapis.com:443"),
  option.WithoutAuthentication())
if err != nil {
  // grpc: no transport security set (use grpc.WithTransportCredentials(insecure.NewCredentials())
  // explicitly or set credentials)
}
```

This is not correct. It makes it very difficult for users to, for example, read a public GCS object without credentials, but using a secure connection.

This may seem like a weird use case, but the HTTP version of `dial` doesn't control connection-level encryption via the `WithoutAuthentication` option - connection certs loaded [here](https://github.com/googleapis/google-api-go-client/blob/main/transport/http/dial.go#L36-L44) while credentials are loaded [here](https://github.com/googleapis/google-api-go-client/blob/main/transport/http/dial.go#L74-L97).

Note: This also refactors the use of `grpc.WithInsecure`, which is no deprecated, to the preferred `grpcinsecure.NewCredentials()` option.