### PR TITLE
chore: ignore some golang.org/x/* dependencies in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,9 @@
   "commitMessageAction": "update",
   "groupName": "all",
   "ignoreDeps": [
-    "golang.org/x/net"
+    "golang.org/x/net",
+    "golang.org/x/sys",
+    "golang.org/x/oauth2"
   ],
   "force": {
     "constraints": {


### PR DESCRIPTION
Related to googleapis/google-cloud-go#7117