### PR TITLE
fix: add better support of array of floats

### DIFF
--- a/androidmanagement/v1/androidmanagement-gen.go
+++ b/androidmanagement/v1/androidmanagement-gen.go
@@ -2838,6 +2838,58 @@ func (s *HardwareInfo) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *HardwareInfo) UnmarshalJSON(data []byte) error {
+	type NoMethod HardwareInfo
+	var s1 struct {
+		BatteryShutdownTemperatures   []gensupport.JSONFloat64 `json:"batteryShutdownTemperatures"`
+		BatteryThrottlingTemperatures []gensupport.JSONFloat64 `json:"batteryThrottlingTemperatures"`
+		CpuShutdownTemperatures       []gensupport.JSONFloat64 `json:"cpuShutdownTemperatures"`
+		CpuThrottlingTemperatures     []gensupport.JSONFloat64 `json:"cpuThrottlingTemperatures"`
+		GpuShutdownTemperatures       []gensupport.JSONFloat64 `json:"gpuShutdownTemperatures"`
+		GpuThrottlingTemperatures     []gensupport.JSONFloat64 `json:"gpuThrottlingTemperatures"`
+		SkinShutdownTemperatures      []gensupport.JSONFloat64 `json:"skinShutdownTemperatures"`
+		SkinThrottlingTemperatures    []gensupport.JSONFloat64 `json:"skinThrottlingTemperatures"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.BatteryShutdownTemperatures = make([]float64, len(s1.BatteryShutdownTemperatures))
+	for i := range s1.BatteryShutdownTemperatures {
+		s.BatteryShutdownTemperatures[i] = float64(s1.BatteryShutdownTemperatures[i])
+	}
+	s.BatteryThrottlingTemperatures = make([]float64, len(s1.BatteryThrottlingTemperatures))
+	for i := range s1.BatteryThrottlingTemperatures {
+		s.BatteryThrottlingTemperatures[i] = float64(s1.BatteryThrottlingTemperatures[i])
+	}
+	s.CpuShutdownTemperatures = make([]float64, len(s1.CpuShutdownTemperatures))
+	for i := range s1.CpuShutdownTemperatures {
+		s.CpuShutdownTemperatures[i] = float64(s1.CpuShutdownTemperatures[i])
+	}
+	s.CpuThrottlingTemperatures = make([]float64, len(s1.CpuThrottlingTemperatures))
+	for i := range s1.CpuThrottlingTemperatures {
+		s.CpuThrottlingTemperatures[i] = float64(s1.CpuThrottlingTemperatures[i])
+	}
+	s.GpuShutdownTemperatures = make([]float64, len(s1.GpuShutdownTemperatures))
+	for i := range s1.GpuShutdownTemperatures {
+		s.GpuShutdownTemperatures[i] = float64(s1.GpuShutdownTemperatures[i])
+	}
+	s.GpuThrottlingTemperatures = make([]float64, len(s1.GpuThrottlingTemperatures))
+	for i := range s1.GpuThrottlingTemperatures {
+		s.GpuThrottlingTemperatures[i] = float64(s1.GpuThrottlingTemperatures[i])
+	}
+	s.SkinShutdownTemperatures = make([]float64, len(s1.SkinShutdownTemperatures))
+	for i := range s1.SkinShutdownTemperatures {
+		s.SkinShutdownTemperatures[i] = float64(s1.SkinShutdownTemperatures[i])
+	}
+	s.SkinThrottlingTemperatures = make([]float64, len(s1.SkinThrottlingTemperatures))
+	for i := range s1.SkinThrottlingTemperatures {
+		s.SkinThrottlingTemperatures[i] = float64(s1.SkinThrottlingTemperatures[i])
+	}
+	return nil
+}
+
 // HardwareStatus: Hardware status. Temperatures may be compared to the
 // temperature thresholds available in hardwareInfo to determine
 // hardware health.
@@ -2892,6 +2944,48 @@ func (s *HardwareStatus) MarshalJSON() ([]byte, error) {
 	type NoMethod HardwareStatus
 	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *HardwareStatus) UnmarshalJSON(data []byte) error {
+	type NoMethod HardwareStatus
+	var s1 struct {
+		BatteryTemperatures []gensupport.JSONFloat64 `json:"batteryTemperatures"`
+		CpuTemperatures     []gensupport.JSONFloat64 `json:"cpuTemperatures"`
+		CpuUsages           []gensupport.JSONFloat64 `json:"cpuUsages"`
+		FanSpeeds           []gensupport.JSONFloat64 `json:"fanSpeeds"`
+		GpuTemperatures     []gensupport.JSONFloat64 `json:"gpuTemperatures"`
+		SkinTemperatures    []gensupport.JSONFloat64 `json:"skinTemperatures"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.BatteryTemperatures = make([]float64, len(s1.BatteryTemperatures))
+	for i := range s1.BatteryTemperatures {
+		s.BatteryTemperatures[i] = float64(s1.BatteryTemperatures[i])
+	}
+	s.CpuTemperatures = make([]float64, len(s1.CpuTemperatures))
+	for i := range s1.CpuTemperatures {
+		s.CpuTemperatures[i] = float64(s1.CpuTemperatures[i])
+	}
+	s.CpuUsages = make([]float64, len(s1.CpuUsages))
+	for i := range s1.CpuUsages {
+		s.CpuUsages[i] = float64(s1.CpuUsages[i])
+	}
+	s.FanSpeeds = make([]float64, len(s1.FanSpeeds))
+	for i := range s1.FanSpeeds {
+		s.FanSpeeds[i] = float64(s1.FanSpeeds[i])
+	}
+	s.GpuTemperatures = make([]float64, len(s1.GpuTemperatures))
+	for i := range s1.GpuTemperatures {
+		s.GpuTemperatures[i] = float64(s1.GpuTemperatures[i])
+	}
+	s.SkinTemperatures = make([]float64, len(s1.SkinTemperatures))
+	for i := range s1.SkinTemperatures {
+		s.SkinTemperatures[i] = float64(s1.SkinTemperatures[i])
+	}
+	return nil
 }
 
 // IssueCommandResponse: Response on issuing a command. This is

--- a/bigquery/v2/bigquery-gen.go
+++ b/bigquery/v2/bigquery-gen.go
@@ -447,14 +447,24 @@ func (s *ArimaCoefficients) MarshalJSON() ([]byte, error) {
 func (s *ArimaCoefficients) UnmarshalJSON(data []byte) error {
 	type NoMethod ArimaCoefficients
 	var s1 struct {
-		InterceptCoefficient gensupport.JSONFloat64 `json:"interceptCoefficient"`
+		AutoRegressiveCoefficients []gensupport.JSONFloat64 `json:"autoRegressiveCoefficients"`
+		InterceptCoefficient       gensupport.JSONFloat64   `json:"interceptCoefficient"`
+		MovingAverageCoefficients  []gensupport.JSONFloat64 `json:"movingAverageCoefficients"`
 		*NoMethod
 	}
 	s1.NoMethod = (*NoMethod)(s)
 	if err := json.Unmarshal(data, &s1); err != nil {
 		return err
 	}
+	s.AutoRegressiveCoefficients = make([]float64, len(s1.AutoRegressiveCoefficients))
+	for i := range s1.AutoRegressiveCoefficients {
+		s.AutoRegressiveCoefficients[i] = float64(s1.AutoRegressiveCoefficients[i])
+	}
 	s.InterceptCoefficient = float64(s1.InterceptCoefficient)
+	s.MovingAverageCoefficients = make([]float64, len(s1.MovingAverageCoefficients))
+	for i := range s1.MovingAverageCoefficients {
+		s.MovingAverageCoefficients[i] = float64(s1.MovingAverageCoefficients[i])
+	}
 	return nil
 }
 
@@ -2655,6 +2665,23 @@ func (s *DoubleCandidates) MarshalJSON() ([]byte, error) {
 	type NoMethod DoubleCandidates
 	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *DoubleCandidates) UnmarshalJSON(data []byte) error {
+	type NoMethod DoubleCandidates
+	var s1 struct {
+		Candidates []gensupport.JSONFloat64 `json:"candidates"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Candidates = make([]float64, len(s1.Candidates))
+	for i := range s1.Candidates {
+		s.Candidates[i] = float64(s1.Candidates[i])
+	}
+	return nil
 }
 
 // DoubleHparamSearchSpace: Search space for a double hyperparameter.

--- a/chromeuxreport/v1/chromeuxreport-gen.go
+++ b/chromeuxreport/v1/chromeuxreport-gen.go
@@ -849,6 +849,23 @@ func (s *TimeseriesBin) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *TimeseriesBin) UnmarshalJSON(data []byte) error {
+	type NoMethod TimeseriesBin
+	var s1 struct {
+		Densities []gensupport.JSONFloat64 `json:"densities"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Densities = make([]float64, len(s1.Densities))
+	for i := range s1.Densities {
+		s.Densities[i] = float64(s1.Densities[i])
+	}
+	return nil
+}
+
 // TimeseriesPercentiles: Percentiles contains synthetic values of a
 // metric at a given statistical percentile. These are used for
 // estimating a metric's value as experienced by a percentage of users

--- a/cloudsearch/v1/cloudsearch-gen.go
+++ b/cloudsearch/v1/cloudsearch-gen.go
@@ -9196,6 +9196,23 @@ func (s *DoubleValues) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *DoubleValues) UnmarshalJSON(data []byte) error {
+	type NoMethod DoubleValues
+	var s1 struct {
+		Values []gensupport.JSONFloat64 `json:"values"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Values = make([]float64, len(s1.Values))
+	for i := range s1.Values {
+		s.Values[i] = float64(s1.Values[i])
+	}
+	return nil
+}
+
 type DriveClientActionMarkup struct {
 	RequestFileScope *RequestFileScope `json:"requestFileScope,omitempty"`
 

--- a/dataflow/v1b3/dataflow-gen.go
+++ b/dataflow/v1b3/dataflow-gen.go
@@ -2263,6 +2263,23 @@ func (s *FloatingPointList) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *FloatingPointList) UnmarshalJSON(data []byte) error {
+	type NoMethod FloatingPointList
+	var s1 struct {
+		Elements []gensupport.JSONFloat64 `json:"elements"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Elements = make([]float64, len(s1.Elements))
+	for i := range s1.Elements {
+		s.Elements[i] = float64(s1.Elements[i])
+	}
+	return nil
+}
+
 // FloatingPointMean: A representation of a floating point mean metric
 // contribution.
 type FloatingPointMean struct {

--- a/dataplex/v1/dataplex-gen.go
+++ b/dataplex/v1/dataplex-gen.go
@@ -1816,10 +1816,11 @@ func (s *GoogleCloudDataplexV1DataProfileResultProfileFieldProfileInfoDoubleFiel
 func (s *GoogleCloudDataplexV1DataProfileResultProfileFieldProfileInfoDoubleFieldInfo) UnmarshalJSON(data []byte) error {
 	type NoMethod GoogleCloudDataplexV1DataProfileResultProfileFieldProfileInfoDoubleFieldInfo
 	var s1 struct {
-		Average           gensupport.JSONFloat64 `json:"average"`
-		Max               gensupport.JSONFloat64 `json:"max"`
-		Min               gensupport.JSONFloat64 `json:"min"`
-		StandardDeviation gensupport.JSONFloat64 `json:"standardDeviation"`
+		Average           gensupport.JSONFloat64   `json:"average"`
+		Max               gensupport.JSONFloat64   `json:"max"`
+		Min               gensupport.JSONFloat64   `json:"min"`
+		Quartiles         []gensupport.JSONFloat64 `json:"quartiles"`
+		StandardDeviation gensupport.JSONFloat64   `json:"standardDeviation"`
 		*NoMethod
 	}
 	s1.NoMethod = (*NoMethod)(s)
@@ -1829,6 +1830,10 @@ func (s *GoogleCloudDataplexV1DataProfileResultProfileFieldProfileInfoDoubleFiel
 	s.Average = float64(s1.Average)
 	s.Max = float64(s1.Max)
 	s.Min = float64(s1.Min)
+	s.Quartiles = make([]float64, len(s1.Quartiles))
+	for i := range s1.Quartiles {
+		s.Quartiles[i] = float64(s1.Quartiles[i])
+	}
 	s.StandardDeviation = float64(s1.StandardDeviation)
 	return nil
 }

--- a/discoveryengine/v1alpha/discoveryengine-gen.go
+++ b/discoveryengine/v1alpha/discoveryengine-gen.go
@@ -880,6 +880,23 @@ func (s *GoogleCloudDiscoveryengineV1alphaCustomAttribute) MarshalJSON() ([]byte
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *GoogleCloudDiscoveryengineV1alphaCustomAttribute) UnmarshalJSON(data []byte) error {
+	type NoMethod GoogleCloudDiscoveryengineV1alphaCustomAttribute
+	var s1 struct {
+		Numbers []gensupport.JSONFloat64 `json:"numbers"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Numbers = make([]float64, len(s1.Numbers))
+	for i := range s1.Numbers {
+		s.Numbers[i] = float64(s1.Numbers[i])
+	}
+	return nil
+}
+
 // GoogleCloudDiscoveryengineV1alphaDocument: Document captures all raw
 // metadata information of items to be recommended or searched.
 type GoogleCloudDiscoveryengineV1alphaDocument struct {

--- a/discoveryengine/v1beta/discoveryengine-gen.go
+++ b/discoveryengine/v1beta/discoveryengine-gen.go
@@ -1115,6 +1115,23 @@ func (s *GoogleCloudDiscoveryengineV1betaCustomAttribute) MarshalJSON() ([]byte,
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *GoogleCloudDiscoveryengineV1betaCustomAttribute) UnmarshalJSON(data []byte) error {
+	type NoMethod GoogleCloudDiscoveryengineV1betaCustomAttribute
+	var s1 struct {
+		Numbers []gensupport.JSONFloat64 `json:"numbers"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Numbers = make([]float64, len(s1.Numbers))
+	for i := range s1.Numbers {
+		s.Numbers[i] = float64(s1.Numbers[i])
+	}
+	return nil
+}
+
 // GoogleCloudDiscoveryengineV1betaDocument: Document captures all raw
 // metadata information of items to be recommended or searched.
 type GoogleCloudDiscoveryengineV1betaDocument struct {

--- a/google-api-go-generator/clients_test.go
+++ b/google-api-go-generator/clients_test.go
@@ -398,6 +398,20 @@ func TestUnmarshalSpecialFloats(t *testing.T) {
 	}
 }
 
+func TestUnmarshalArrayFloats(t *testing.T) {
+	in := `{"bounds": [3, "Infinity", "-Infinity", "NaN"]}`
+	want := []float64{3, math.Inf(1), math.Inf(-1), math.NaN()}
+	var got mon.Explicit
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatal(err)
+	}
+	for i := range want {
+		if !fleq(got.Bounds[i], want[i]) {
+			t.Errorf("got\n%+v\nwant\n%+v", got.Bounds[i], want)
+		}
+	}
+}
+
 func fleq(f1, f2 float64) bool {
 	return f1 == f2 || (math.IsNaN(f1) && math.IsNaN(f2))
 }

--- a/google-api-go-generator/testdata/json-body.want
+++ b/google-api-go-generator/testdata/json-body.want
@@ -1314,13 +1314,18 @@ func (s *GoogleCloudMlV1__ParameterSpec) MarshalJSON() ([]byte, error) {
 func (s *GoogleCloudMlV1__ParameterSpec) UnmarshalJSON(data []byte) error {
 	type NoMethod GoogleCloudMlV1__ParameterSpec
 	var s1 struct {
-		MaxValue gensupport.JSONFloat64 `json:"maxValue"`
-		MinValue gensupport.JSONFloat64 `json:"minValue"`
+		DiscreteValues []gensupport.JSONFloat64 `json:"discreteValues"`
+		MaxValue       gensupport.JSONFloat64   `json:"maxValue"`
+		MinValue       gensupport.JSONFloat64   `json:"minValue"`
 		*NoMethod
 	}
 	s1.NoMethod = (*NoMethod)(s)
 	if err := json.Unmarshal(data, &s1); err != nil {
 		return err
+	}
+	s.DiscreteValues = make([]float64, len(s1.DiscreteValues))
+	for i := range s1.DiscreteValues {
+		s.DiscreteValues[i] = float64(s1.DiscreteValues[i])
 	}
 	s.MaxValue = float64(s1.MaxValue)
 	s.MinValue = float64(s1.MinValue)

--- a/google-api-go-generator/testdata/variants.want
+++ b/google-api-go-generator/testdata/variants.want
@@ -475,6 +475,23 @@ func (s *MapFolder) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *MapFolder) UnmarshalJSON(data []byte) error {
+	type NoMethod MapFolder
+	var s1 struct {
+		DefaultViewport []gensupport.JSONFloat64 `json:"defaultViewport"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.DefaultViewport = make([]float64, len(s1.DefaultViewport))
+	for i := range s1.DefaultViewport {
+		s.DefaultViewport[i] = float64(s1.DefaultViewport[i])
+	}
+	return nil
+}
+
 type MapItem map[string]interface{}
 
 func (t MapItem) Type() string {
@@ -551,6 +568,23 @@ func (s *MapKmlLink) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *MapKmlLink) UnmarshalJSON(data []byte) error {
+	type NoMethod MapKmlLink
+	var s1 struct {
+		DefaultViewport []gensupport.JSONFloat64 `json:"defaultViewport"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.DefaultViewport = make([]float64, len(s1.DefaultViewport))
+	for i := range s1.DefaultViewport {
+		s.DefaultViewport[i] = float64(s1.DefaultViewport[i])
+	}
+	return nil
+}
+
 type MapLayer struct {
 	// DefaultViewport: An array of four numbers (west, south, east, north)
 	// which defines the rectangular bounding box of the default viewport.
@@ -599,4 +633,21 @@ func (s *MapLayer) MarshalJSON() ([]byte, error) {
 	type NoMethod MapLayer
 	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *MapLayer) UnmarshalJSON(data []byte) error {
+	type NoMethod MapLayer
+	var s1 struct {
+		DefaultViewport []gensupport.JSONFloat64 `json:"defaultViewport"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.DefaultViewport = make([]float64, len(s1.DefaultViewport))
+	for i := range s1.DefaultViewport {
+		s.DefaultViewport[i] = float64(s1.DefaultViewport[i])
+	}
+	return nil
 }

--- a/integrations/v1alpha/integrations-gen.go
+++ b/integrations/v1alpha/integrations-gen.go
@@ -1379,6 +1379,23 @@ func (s *EnterpriseCrmEventbusProtoDoubleArray) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *EnterpriseCrmEventbusProtoDoubleArray) UnmarshalJSON(data []byte) error {
+	type NoMethod EnterpriseCrmEventbusProtoDoubleArray
+	var s1 struct {
+		Values []gensupport.JSONFloat64 `json:"values"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Values = make([]float64, len(s1.Values))
+	for i := range s1.Values {
+		s.Values[i] = float64(s1.Values[i])
+	}
+	return nil
+}
+
 type EnterpriseCrmEventbusProtoDoubleArrayFunction struct {
 	// Possible values:
 	//   "UNSPECIFIED"
@@ -1491,6 +1508,23 @@ func (s *EnterpriseCrmEventbusProtoDoubleParameterArray) MarshalJSON() ([]byte, 
 	type NoMethod EnterpriseCrmEventbusProtoDoubleParameterArray
 	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *EnterpriseCrmEventbusProtoDoubleParameterArray) UnmarshalJSON(data []byte) error {
+	type NoMethod EnterpriseCrmEventbusProtoDoubleParameterArray
+	var s1 struct {
+		DoubleValues []gensupport.JSONFloat64 `json:"doubleValues"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.DoubleValues = make([]float64, len(s1.DoubleValues))
+	for i := range s1.DoubleValues {
+		s.DoubleValues[i] = float64(s1.DoubleValues[i])
+	}
+	return nil
 }
 
 // EnterpriseCrmEventbusProtoErrorDetail: An error, warning, or
@@ -4787,6 +4821,23 @@ func (s *EnterpriseCrmFrontendsEventbusProtoDoubleParameterArray) MarshalJSON() 
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *EnterpriseCrmFrontendsEventbusProtoDoubleParameterArray) UnmarshalJSON(data []byte) error {
+	type NoMethod EnterpriseCrmFrontendsEventbusProtoDoubleParameterArray
+	var s1 struct {
+		DoubleValues []gensupport.JSONFloat64 `json:"doubleValues"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.DoubleValues = make([]float64, len(s1.DoubleValues))
+	for i := range s1.DoubleValues {
+		s.DoubleValues[i] = float64(s1.DoubleValues[i])
+	}
+	return nil
+}
+
 // EnterpriseCrmFrontendsEventbusProtoEventExecutionDetails: Contains
 // the details of the execution info of this event: this includes the
 // tasks execution details plus the event execution statistics. Next
@@ -7699,6 +7750,23 @@ func (s *GoogleCloudIntegrationsV1alphaDoubleParameterArray) MarshalJSON() ([]by
 	type NoMethod GoogleCloudIntegrationsV1alphaDoubleParameterArray
 	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *GoogleCloudIntegrationsV1alphaDoubleParameterArray) UnmarshalJSON(data []byte) error {
+	type NoMethod GoogleCloudIntegrationsV1alphaDoubleParameterArray
+	var s1 struct {
+		DoubleValues []gensupport.JSONFloat64 `json:"doubleValues"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.DoubleValues = make([]float64, len(s1.DoubleValues))
+	for i := range s1.DoubleValues {
+		s.DoubleValues[i] = float64(s1.DoubleValues[i])
+	}
+	return nil
 }
 
 // GoogleCloudIntegrationsV1alphaDownloadIntegrationVersionResponse:

--- a/jobs/v3/jobs-gen.go
+++ b/jobs/v3/jobs-gen.go
@@ -2950,6 +2950,23 @@ func (s *NumericBucketingOption) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *NumericBucketingOption) UnmarshalJSON(data []byte) error {
+	type NoMethod NumericBucketingOption
+	var s1 struct {
+		BucketBounds []gensupport.JSONFloat64 `json:"bucketBounds"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.BucketBounds = make([]float64, len(s1.BucketBounds))
+	for i := range s1.BucketBounds {
+		s.BucketBounds[i] = float64(s1.BucketBounds[i])
+	}
+	return nil
+}
+
 // NumericBucketingResult: Output only. Custom numeric bucketing result.
 type NumericBucketingResult struct {
 	// Counts: Count within each bucket. Its size is the length of

--- a/jobs/v3p1beta1/jobs-gen.go
+++ b/jobs/v3p1beta1/jobs-gen.go
@@ -3172,6 +3172,23 @@ func (s *NumericBucketingOption) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *NumericBucketingOption) UnmarshalJSON(data []byte) error {
+	type NoMethod NumericBucketingOption
+	var s1 struct {
+		BucketBounds []gensupport.JSONFloat64 `json:"bucketBounds"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.BucketBounds = make([]float64, len(s1.BucketBounds))
+	for i := range s1.BucketBounds {
+		s.BucketBounds[i] = float64(s1.BucketBounds[i])
+	}
+	return nil
+}
+
 // NumericBucketingResult: Output only. Custom numeric bucketing result.
 type NumericBucketingResult struct {
 	// Counts: Count within each bucket. Its size is the length of

--- a/logging/v2/logging-gen.go
+++ b/logging/v2/logging-gen.go
@@ -1350,6 +1350,23 @@ func (s *Explicit) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *Explicit) UnmarshalJSON(data []byte) error {
+	type NoMethod Explicit
+	var s1 struct {
+		Bounds []gensupport.JSONFloat64 `json:"bounds"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Bounds = make([]float64, len(s1.Bounds))
+	for i := range s1.Bounds {
+		s.Bounds[i] = float64(s1.Bounds[i])
+	}
+	return nil
+}
+
 // Exponential: Specifies an exponential sequence of buckets that have a
 // width that is proportional to the value of the lower bound. Each
 // bucket represents a constant relative uncertainty on a specific value

--- a/migrationcenter/v1alpha1/migrationcenter-gen.go
+++ b/migrationcenter/v1alpha1/migrationcenter-gen.go
@@ -469,6 +469,23 @@ func (s *AggregationHistogram) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *AggregationHistogram) UnmarshalJSON(data []byte) error {
+	type NoMethod AggregationHistogram
+	var s1 struct {
+		LowerBounds []gensupport.JSONFloat64 `json:"lowerBounds"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.LowerBounds = make([]float64, len(s1.LowerBounds))
+	for i := range s1.LowerBounds {
+		s.LowerBounds[i] = float64(s1.LowerBounds[i])
+	}
+	return nil
+}
+
 // AggregationResult: Message describing a result of an aggregation.
 type AggregationResult struct {
 	Count *AggregationResultCount `json:"count,omitempty"`

--- a/ml/v1/ml-gen.go
+++ b/ml/v1/ml-gen.go
@@ -527,6 +527,23 @@ func (s *GoogleCloudMlV1StudyConfigParameterSpecDiscreteValueSpec) MarshalJSON()
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *GoogleCloudMlV1StudyConfigParameterSpecDiscreteValueSpec) UnmarshalJSON(data []byte) error {
+	type NoMethod GoogleCloudMlV1StudyConfigParameterSpecDiscreteValueSpec
+	var s1 struct {
+		Values []gensupport.JSONFloat64 `json:"values"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Values = make([]float64, len(s1.Values))
+	for i := range s1.Values {
+		s.Values[i] = float64(s1.Values[i])
+	}
+	return nil
+}
+
 type GoogleCloudMlV1StudyConfigParameterSpecDoubleValueSpec struct {
 	// MaxValue: Must be specified if type is `DOUBLE`. Maximum value of the
 	// parameter.
@@ -667,6 +684,23 @@ func (s *GoogleCloudMlV1StudyConfigParameterSpecMatchingParentDiscreteValueSpec)
 	type NoMethod GoogleCloudMlV1StudyConfigParameterSpecMatchingParentDiscreteValueSpec
 	raw := NoMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *GoogleCloudMlV1StudyConfigParameterSpecMatchingParentDiscreteValueSpec) UnmarshalJSON(data []byte) error {
+	type NoMethod GoogleCloudMlV1StudyConfigParameterSpecMatchingParentDiscreteValueSpec
+	var s1 struct {
+		Values []gensupport.JSONFloat64 `json:"values"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Values = make([]float64, len(s1.Values))
+	for i := range s1.Values {
+		s.Values[i] = float64(s1.Values[i])
+	}
+	return nil
 }
 
 // GoogleCloudMlV1StudyConfigParameterSpecMatchingParentIntValueSpec:
@@ -2646,13 +2680,18 @@ func (s *GoogleCloudMlV1__ParameterSpec) MarshalJSON() ([]byte, error) {
 func (s *GoogleCloudMlV1__ParameterSpec) UnmarshalJSON(data []byte) error {
 	type NoMethod GoogleCloudMlV1__ParameterSpec
 	var s1 struct {
-		MaxValue gensupport.JSONFloat64 `json:"maxValue"`
-		MinValue gensupport.JSONFloat64 `json:"minValue"`
+		DiscreteValues []gensupport.JSONFloat64 `json:"discreteValues"`
+		MaxValue       gensupport.JSONFloat64   `json:"maxValue"`
+		MinValue       gensupport.JSONFloat64   `json:"minValue"`
 		*NoMethod
 	}
 	s1.NoMethod = (*NoMethod)(s)
 	if err := json.Unmarshal(data, &s1); err != nil {
 		return err
+	}
+	s.DiscreteValues = make([]float64, len(s1.DiscreteValues))
+	for i := range s1.DiscreteValues {
+		s.DiscreteValues[i] = float64(s1.DiscreteValues[i])
 	}
 	s.MaxValue = float64(s1.MaxValue)
 	s.MinValue = float64(s1.MinValue)

--- a/monitoring/v3/monitoring-gen.go
+++ b/monitoring/v3/monitoring-gen.go
@@ -2009,6 +2009,23 @@ func (s *Explicit) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *Explicit) UnmarshalJSON(data []byte) error {
+	type NoMethod Explicit
+	var s1 struct {
+		Bounds []gensupport.JSONFloat64 `json:"bounds"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Bounds = make([]float64, len(s1.Bounds))
+	for i := range s1.Bounds {
+		s.Bounds[i] = float64(s1.Bounds[i])
+	}
+	return nil
+}
+
 // Exponential: Specifies an exponential sequence of buckets that have a
 // width that is proportional to the value of the lower bound. Each
 // bucket represents a constant relative uncertainty on a specific value

--- a/recommendationengine/v1beta1/recommendationengine-gen.go
+++ b/recommendationengine/v1beta1/recommendationengine-gen.go
@@ -862,6 +862,23 @@ func (s *GoogleCloudRecommendationengineV1beta1FeatureMapFloatList) MarshalJSON(
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *GoogleCloudRecommendationengineV1beta1FeatureMapFloatList) UnmarshalJSON(data []byte) error {
+	type NoMethod GoogleCloudRecommendationengineV1beta1FeatureMapFloatList
+	var s1 struct {
+		Value []gensupport.JSONFloat64 `json:"value"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Value = make([]float64, len(s1.Value))
+	for i := range s1.Value {
+		s.Value[i] = float64(s1.Value[i])
+	}
+	return nil
+}
+
 // GoogleCloudRecommendationengineV1beta1FeatureMapStringList: A list of
 // string features.
 type GoogleCloudRecommendationengineV1beta1FeatureMapStringList struct {

--- a/retail/v2/retail-gen.go
+++ b/retail/v2/retail-gen.go
@@ -1776,6 +1776,23 @@ func (s *GoogleCloudRetailV2CustomAttribute) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *GoogleCloudRetailV2CustomAttribute) UnmarshalJSON(data []byte) error {
+	type NoMethod GoogleCloudRetailV2CustomAttribute
+	var s1 struct {
+		Numbers []gensupport.JSONFloat64 `json:"numbers"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Numbers = make([]float64, len(s1.Numbers))
+	for i := range s1.Numbers {
+		s.Numbers[i] = float64(s1.Numbers[i])
+	}
+	return nil
+}
+
 // GoogleCloudRetailV2ExperimentInfo: Metadata for active A/B testing
 // Experiment.
 type GoogleCloudRetailV2ExperimentInfo struct {

--- a/retail/v2alpha/retail-gen.go
+++ b/retail/v2alpha/retail-gen.go
@@ -2808,6 +2808,23 @@ func (s *GoogleCloudRetailV2alphaCustomAttribute) MarshalJSON() ([]byte, error) 
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *GoogleCloudRetailV2alphaCustomAttribute) UnmarshalJSON(data []byte) error {
+	type NoMethod GoogleCloudRetailV2alphaCustomAttribute
+	var s1 struct {
+		Numbers []gensupport.JSONFloat64 `json:"numbers"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Numbers = make([]float64, len(s1.Numbers))
+	for i := range s1.Numbers {
+		s.Numbers[i] = float64(s1.Numbers[i])
+	}
+	return nil
+}
+
 // GoogleCloudRetailV2alphaExperimentInfo: Metadata for active A/B
 // testing Experiment.
 type GoogleCloudRetailV2alphaExperimentInfo struct {

--- a/retail/v2beta/retail-gen.go
+++ b/retail/v2beta/retail-gen.go
@@ -4074,6 +4074,23 @@ func (s *GoogleCloudRetailV2betaCustomAttribute) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *GoogleCloudRetailV2betaCustomAttribute) UnmarshalJSON(data []byte) error {
+	type NoMethod GoogleCloudRetailV2betaCustomAttribute
+	var s1 struct {
+		Numbers []gensupport.JSONFloat64 `json:"numbers"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Numbers = make([]float64, len(s1.Numbers))
+	for i := range s1.Numbers {
+		s.Numbers[i] = float64(s1.Numbers[i])
+	}
+	return nil
+}
+
 // GoogleCloudRetailV2betaExperimentInfo: Metadata for active A/B
 // testing Experiment.
 type GoogleCloudRetailV2betaExperimentInfo struct {

--- a/servicecontrol/v1/servicecontrol-gen.go
+++ b/servicecontrol/v1/servicecontrol-gen.go
@@ -1133,6 +1133,23 @@ func (s *ExplicitBuckets) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *ExplicitBuckets) UnmarshalJSON(data []byte) error {
+	type NoMethod ExplicitBuckets
+	var s1 struct {
+		Bounds []gensupport.JSONFloat64 `json:"bounds"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Bounds = make([]float64, len(s1.Bounds))
+	for i := range s1.Bounds {
+		s.Bounds[i] = float64(s1.Bounds[i])
+	}
+	return nil
+}
+
 // ExponentialBuckets: Describing buckets with exponentially growing
 // width.
 type ExponentialBuckets struct {

--- a/spanner/v1/spanner-gen.go
+++ b/spanner/v1/spanner-gen.go
@@ -3390,6 +3390,23 @@ func (s *MetricMatrixRow) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *MetricMatrixRow) UnmarshalJSON(data []byte) error {
+	type NoMethod MetricMatrixRow
+	var s1 struct {
+		Cols []gensupport.JSONFloat64 `json:"cols"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Cols = make([]float64, len(s1.Cols))
+	for i := range s1.Cols {
+		s.Cols[i] = float64(s1.Cols[i])
+	}
+	return nil
+}
+
 // Mutation: A modification to one or more Cloud Spanner rows. Mutations
 // can be applied to a Cloud Spanner database by sending them in a
 // Commit call.

--- a/vision/v1/vision-gen.go
+++ b/vision/v1/vision-gen.go
@@ -1386,6 +1386,23 @@ func (s *CropHintsParams) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *CropHintsParams) UnmarshalJSON(data []byte) error {
+	type NoMethod CropHintsParams
+	var s1 struct {
+		AspectRatios []gensupport.JSONFloat64 `json:"aspectRatios"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.AspectRatios = make([]float64, len(s1.AspectRatios))
+	for i := range s1.AspectRatios {
+		s.AspectRatios[i] = float64(s1.AspectRatios[i])
+	}
+	return nil
+}
+
 // DetectedBreak: Detected start or end of a structural component.
 type DetectedBreak struct {
 	// IsPrefix: True if break prepends the element.

--- a/vision/v1p1beta1/vision-gen.go
+++ b/vision/v1p1beta1/vision-gen.go
@@ -2146,6 +2146,23 @@ func (s *GoogleCloudVisionV1p1beta1CropHintsParams) MarshalJSON() ([]byte, error
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *GoogleCloudVisionV1p1beta1CropHintsParams) UnmarshalJSON(data []byte) error {
+	type NoMethod GoogleCloudVisionV1p1beta1CropHintsParams
+	var s1 struct {
+		AspectRatios []gensupport.JSONFloat64 `json:"aspectRatios"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.AspectRatios = make([]float64, len(s1.AspectRatios))
+	for i := range s1.AspectRatios {
+		s.AspectRatios[i] = float64(s1.AspectRatios[i])
+	}
+	return nil
+}
+
 // GoogleCloudVisionV1p1beta1DominantColorsAnnotation: Set of dominant
 // colors and their corresponding scores.
 type GoogleCloudVisionV1p1beta1DominantColorsAnnotation struct {

--- a/vision/v1p2beta1/vision-gen.go
+++ b/vision/v1p2beta1/vision-gen.go
@@ -4446,6 +4446,23 @@ func (s *GoogleCloudVisionV1p2beta1CropHintsParams) MarshalJSON() ([]byte, error
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+func (s *GoogleCloudVisionV1p2beta1CropHintsParams) UnmarshalJSON(data []byte) error {
+	type NoMethod GoogleCloudVisionV1p2beta1CropHintsParams
+	var s1 struct {
+		AspectRatios []gensupport.JSONFloat64 `json:"aspectRatios"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.AspectRatios = make([]float64, len(s1.AspectRatios))
+	for i := range s1.AspectRatios {
+		s.AspectRatios[i] = float64(s1.AspectRatios[i])
+	}
+	return nil
+}
+
 // GoogleCloudVisionV1p2beta1DominantColorsAnnotation: Set of dominant
 // colors and their corresponding scores.
 type GoogleCloudVisionV1p2beta1DominantColorsAnnotation struct {


### PR DESCRIPTION
Just like normal floats our arrary of floats should be able to
handle things like "NaN".

Fixes: https://github.com/googleapis/google-api-go-client/issues/1970