### PR TITLE
chore(ci): fix AutoApprove for discogen

### DIFF
--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -7,10 +7,14 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    if: contains(github.head_ref, 'autosynth')
+    if: contains(github.head_ref, 'discogen')
     env:
       ENABLE_AUTO_APPROVE: ${{ secrets.ENABLE_AUTO_APPROVE }}
     steps:


### PR DESCRIPTION
Changes AutoApprove to target PRs from the `discogen` branch.

Adds explicit workflow permissions.

Fixes #1980 