### PR TITLE
chore: temporarily give AutoApprove job full write

### DIFF
--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -7,9 +7,7 @@ on:
     types:
       - opened
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: write-all
 
 jobs:
   auto-approve:


### PR DESCRIPTION
The [docs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) don't indicate what `permissions` would apply to fixing the [`createReview` issue](https://github.com/googleapis/google-api-go-client/actions/runs/5011498932/jobs/8982392653?pr=1982). But I'm also not sure if these perms actually apply to the `YOSHI_APPROVER_TOKEN` used for all of the API calls.

This should be temporary until we find the right perms.