### PR TITLE
chore: enable GoApiaryCodegen auto-approve

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 # Default owner for all directories not owned by others
-* @googleapis/yoshi-go-admins @yoshi-approver
+* @googleapis/yoshi-go-admins
+.github/auto-approve.yml                 @googleapis/github-automation
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default owner for all directories not owned by others
 * @googleapis/yoshi-go-admins
-.github/auto-approve.yml                 @googleapis/github-automation
+.github/auto-approve.yml @googleapis/github-automation
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,2 @@
 # Default owner for all directories not owned by others
 * @googleapis/yoshi-go-admins
-.github/auto-approve.yml @googleapis/github-automation
-

--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -1,0 +1,2 @@
+processes:
+  - "GoApiaryCodegen"


### PR DESCRIPTION
Enables the new `GoApiaryCodegen` config with `auto-approve` to approve the Apiary/Discovery regeneration PRs like [this](https://github.com/googleapis/google-api-go-client/pull/1982).