### PR TITLE
chore: skip generating integrations:v1alpha as it fails generation

### DIFF
--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -67,8 +67,8 @@ var (
 
 // skipAPIGeneration is a set of APIs to not generate when generating all clients.
 var skipAPIGeneration = map[string]bool{
-	"integrations:v1": true,
-	"sql:v1beta4":     true,
+	"integrations:v1alpha": true,
+	"sql:v1beta4":          true,
 }
 
 // API represents an API to generate, as well as its state while it's

--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -68,7 +68,7 @@ var (
 // skipAPIGeneration is a set of APIs to not generate when generating all clients.
 var skipAPIGeneration = map[string]bool{
 	"integrations:v1": true,
-	"sql:v1beta4": true,
+	"sql:v1beta4":     true,
 }
 
 // API represents an API to generate, as well as its state while it's

--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -67,6 +67,7 @@ var (
 
 // skipAPIGeneration is a set of APIs to not generate when generating all clients.
 var skipAPIGeneration = map[string]bool{
+	"integrations:v1": true,
 	"sql:v1beta4": true,
 }
 


### PR DESCRIPTION
Restore this API once the ExecuteEvent RPC definition is valid. See internal issue b/286436239.