### PR TITLE
chore: skip generating integrations:v1alpha

### DIFF
--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -67,7 +67,8 @@ var (
 
 // skipAPIGeneration is a set of APIs to not generate when generating all clients.
 var skipAPIGeneration = map[string]bool{
-	"sql:v1beta4": true,
+	"integrations:v1alpha": true,
+	"sql:v1beta4":          true,
 }
 
 // API represents an API to generate, as well as its state while it's


### PR DESCRIPTION
refs: #2037
refs: #2014

Unfortunately, reinstating `integrations/v1alpha` broke the build again. Therefore I will revert PR #2037 and skip it again in the generation.

```
2023/06/26 07:09:48 Generating API integrations:v1alpha
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xd8 pc=0x6c06c7]

goroutine 1 [running]:
main.(*Method).NewBodyArg(0xc0004674a0?, 0xc02b641590)
	/tmpfs/src/github/google-api-go-client/google-api-go-generator/gen.go:2437 +0x27
main.(*Method).NewArguments(0xc0001fdc20)
	/tmpfs/src/github/google-api-go-client/google-api-go-generator/gen.go:2430 +0x297
main.(*Method).generateCode(0xc0001fdc20)
	/tmpfs/src/github/google-api-go-client/google-api-go-generator/gen.go:1835 +0x236
main.(*API).generateResourceMethods(0xc00024c630, 0xc02657e320)
	/tmpfs/src/github/google-api-go-client/google-api-go-generator/gen.go:1596 +0x1aa
main.(*API).generateResourceMethods(0xc00024c630, 0xc02657e0f0)
	/tmpfs/src/github/google-api-go-client/google-api-go-generator/gen.go:1599 +0x1f8
main.(*API).generateResourceMethods(0xc00024c630, 0xc02657e0a0)
	/tmpfs/src/github/google-api-go-client/google-api-go-generator/gen.go:1599 +0x1f8
main.(*API).GenerateCode(0xc00024c630)
	/tmpfs/src/github/google-api-go-client/google-api-go-generator/gen.go:825 +0x2b3c
main.(*API).WriteGeneratedCode(0xc00024c630)
	/tmpfs/src/github/google-api-go-client/google-api-go-generator/gen.go:578 +0x206
main.main()
	/tmpfs/src/github/google-api-go-client/google-api-go-generator/gen.go:148 +0x336
make: *** [Makefile:12: all] Error 2
2023/06/26 07:09:48 unable to generate discovery clients: exit status 2
exit status 1
cleanup
```