### PR TITLE
chore: fix discogen

### DIFF
--- a/internal/kokoro/discogen.sh
+++ b/internal/kokoro/discogen.sh
@@ -12,6 +12,9 @@ export GITHUB_ACCESS_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/73713_yoshi-automation-git
 # Display commands being run
 set -x
 
+# Needed for our build environment
+go env -w GOFLAGS="-buildvcs=false"
+
 # cd to project dir on Kokoro instance
 cd github/google-api-go-client
 export DISCOVERY_DIR=$(pwd)


### PR DESCRIPTION
From our logs:

```
go build -o google-api-go-generator
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
unable to generate discovery clients: exit status 2
```