### PR TITLE
chore: remove added build flag for discogen

### DIFF
--- a/internal/kokoro/discogen.sh
+++ b/internal/kokoro/discogen.sh
@@ -12,9 +12,6 @@ export GITHUB_ACCESS_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/73713_yoshi-automation-git
 # Display commands being run
 set -x
 
-# Needed for our build environment
-go env -w GOFLAGS="-buildvcs=false"
-
 # cd to project dir on Kokoro instance
 cd github/google-api-go-client
 export DISCOVERY_DIR=$(pwd)


### PR DESCRIPTION
This issue was a symptom of an underlying problem. Trying to root cause this by rolling back to original behaviour