### PR TITLE
chore(deps): temporarily ignore grpc dep

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,8 @@
   "commitMessageAction": "update",
   "groupName": "all",
   "ignoreDeps": [
-    "google.golang.org/appengine"
+    "google.golang.org/appengine",
+    "google.golang.org/grpc"
   ],
   "force": {
     "constraints": {


### PR DESCRIPTION
Temporarily ignore the grpc-go dep until we can increase the floor Go version to Go 1.19: #2153 