### PR TITLE
feat(internal): add some feature flags for new auth libs

### DIFF
--- a/internal/settings.go
+++ b/internal/settings.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
-	"strings"
+	"strconv"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -85,8 +85,11 @@ func (ds *DialSettings) HasCustomAudience() bool {
 }
 
 func (ds *DialSettings) IsNewAuthLibraryEnabled() bool {
-	if ds.EnableNewAuthLibrary || strings.ToLower(os.Getenv(newAuthLibEnVar)) == "true" {
+	if ds.EnableNewAuthLibrary {
 		return true
+	}
+	if b, err := strconv.ParseBool(os.Getenv(newAuthLibEnVar)); err == nil {
+		return b
 	}
 	return false
 }

--- a/internal/settings.go
+++ b/internal/settings.go
@@ -9,11 +9,17 @@ import (
 	"crypto/tls"
 	"errors"
 	"net/http"
+	"os"
+	"strings"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/internal/impersonate"
 	"google.golang.org/grpc"
+)
+
+const (
+	newAuthLibEnVar = "GOOGLE_API_GO_EXPERIMENTAL_USE_NEW_AUTH_LIB"
 )
 
 // DialSettings holds information needed to establish a connection with a
@@ -47,6 +53,7 @@ type DialSettings struct {
 	ImpersonationConfig           *impersonate.Config
 	EnableDirectPath              bool
 	EnableDirectPathXds           bool
+	EnableNewAuthLibrary          bool
 	AllowNonDefaultServiceAccount bool
 
 	// Google API system parameters. For more information please read:
@@ -75,6 +82,13 @@ func (ds *DialSettings) GetAudience() string {
 // HasCustomAudience returns true if a custom audience is provided by users.
 func (ds *DialSettings) HasCustomAudience() bool {
 	return len(ds.Audiences) > 0
+}
+
+func (ds *DialSettings) IsNewAuthLibraryEnabled() bool {
+	if ds.EnableNewAuthLibrary || strings.ToLower(os.Getenv(newAuthLibEnVar)) == "true" {
+		return true
+	}
+	return false
 }
 
 // Validate reports an error if ds is invalid.

--- a/option/internaloption/internaloption.go
+++ b/option/internaloption/internaloption.go
@@ -150,6 +150,19 @@ func (w *withCreds) Apply(o *internal.DialSettings) {
 	o.InternalCredentials = (*google.Credentials)(w)
 }
 
+// EnableNewAuthLibrary returns a ClientOption that specifies if libraries in this
+// module to delegate auth to our new library. This option will be removed in
+// the future once all clients have been moved to the new auth layer.
+func EnableNewAuthLibrary() option.ClientOption {
+	return enableNewAuthLibrary(true)
+}
+
+type enableNewAuthLibrary bool
+
+func (w enableNewAuthLibrary) Apply(o *internal.DialSettings) {
+	o.EnableNewAuthLibrary = bool(w)
+}
+
 // EmbeddableAdapter is a no-op option.ClientOption that allow libraries to
 // create their own client options by embedding this type into their own
 // client-specific option wrapper. See example for usage.


### PR DESCRIPTION
We will use the internaloption to start to enable new auth lib for a small number of clients in the future. The envvar will be undocumented and used exclusively in our own testing environments. We will enable it on all of our repos as the first part of functional testing that all existing integration tests continue to work as normal when routing through the new auth layers.