### PR TITLE
chore(deps): ignore go-github

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,8 @@
   "commitMessageAction": "update",
   "groupName": "all",
   "ignoreDeps": [
-    "google.golang.org/appengine"
+    "google.golang.org/appengine",
+    "github.com/google/go-github"
   ],
   "force": {
     "constraints": {


### PR DESCRIPTION
Ignores updates to `go-github` which requires an import path update as well, so [renovate PRs](https://github.com/googleapis/google-api-go-client/pull/2221) are useless.