### PR TITLE
chore(deps): ignore google/go-github package updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,8 +12,13 @@
   "commitMessageAction": "update",
   "groupName": "all",
   "ignoreDeps": [
-    "google.golang.org/appengine",
-    "github.com/google/go-github"
+    "google.golang.org/appengine"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["^github.com/google/go-github/v"],
+      "enabled": false
+    }
   ],
   "force": {
     "constraints": {


### PR DESCRIPTION
"properly" ignore `github.com/google/go-github` dependency updates via renovate since they require code changes (import path updates). Since the module name is changed with each release, we cannot `ignoreDeps` a single module, and [`ignoreDeps` does not support pattern matching, but has a workaround](https://docs.renovatebot.com/configuration-options/#ignoredeps), which I've implemented here.