### PR TITLE
fix(google-api-go-generator): remove unneeded internaloption.WithDefaultUniverseDomain

### DIFF
--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -778,7 +778,6 @@ func (a *API) GenerateCode() ([]byte, error) {
 	if mtlsBase := a.mtlsAPIBaseURL(); mtlsBase != "" {
 		pn("const mtlsBasePath = %q", mtlsBase)
 	}
-	pn("const defaultUniverseDomain = %q", googleDefaultUniverse)
 
 	a.generateScopeConstants()
 	a.PopulateSchemas()
@@ -805,7 +804,6 @@ func (a *API) GenerateCode() ([]byte, error) {
 	if a.mtlsAPIBaseURL() != "" {
 		pn("opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))")
 	}
-	pn("opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))")
 	pn("client, endpoint, err := htransport.NewClient(ctx, opts...)")
 	pn("if err != nil { return nil, err }")
 	pn("s, err := New(client)")

--- a/google-api-go-generator/testdata/any.want
+++ b/google-api-go-generator/testdata/any.want
@@ -92,7 +92,6 @@ const apiVersion = "v1beta3"
 const basePath = "https://logging.googleapis.com/"
 const basePathTemplate = "https://logging.UNIVERSE_DOMAIN/"
 const mtlsBasePath = "https://logging.mtls.googleapis.com/"
-const defaultUniverseDomain = "googleapis.com"
 
 // OAuth2 scopes used by this API.
 const (
@@ -110,7 +109,6 @@ func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, err
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/arrayofarray-1.want
+++ b/google-api-go-generator/testdata/arrayofarray-1.want
@@ -89,13 +89,11 @@ const apiName = "arrayofarray"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/arrayofenum.want
+++ b/google-api-go-generator/testdata/arrayofenum.want
@@ -89,13 +89,11 @@ const apiName = "arrayofenum"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/arrayofmapofobjects.want
+++ b/google-api-go-generator/testdata/arrayofmapofobjects.want
@@ -89,13 +89,11 @@ const apiName = "arrayofmapofstrings"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/arrayofmapofstrings.want
+++ b/google-api-go-generator/testdata/arrayofmapofstrings.want
@@ -89,13 +89,11 @@ const apiName = "arrayofmapofstrings"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/blogger-3.want
+++ b/google-api-go-generator/testdata/blogger-3.want
@@ -97,7 +97,6 @@ const apiVersion = "v3"
 const basePath = "https://www.googleapis.com/blogger/v3/"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/blogger/v3/"
 const mtlsBasePath = "https://www.mtls.googleapis.com/blogger/v3/"
-const defaultUniverseDomain = "googleapis.com"
 
 // OAuth2 scopes used by this API.
 const (
@@ -119,7 +118,6 @@ func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, err
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/floats.want
+++ b/google-api-go-generator/testdata/floats.want
@@ -92,14 +92,12 @@ const apiVersion = "v1"
 const basePath = "https://appengine.googleapis.com/"
 const basePathTemplate = "https://appengine.UNIVERSE_DOMAIN/"
 const mtlsBasePath = "https://appengine.mtls.googleapis.com/"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/getwithoutbody.want
+++ b/google-api-go-generator/testdata/getwithoutbody.want
@@ -89,13 +89,11 @@ const apiName = "getwithoutbody"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/http-body.want
+++ b/google-api-go-generator/testdata/http-body.want
@@ -92,7 +92,6 @@ const apiVersion = "v1beta1"
 const basePath = "https://healthcare.googleapis.com/"
 const basePathTemplate = "https://healthcare.UNIVERSE_DOMAIN/"
 const mtlsBasePath = "https://healthcare.mtls.googleapis.com/"
-const defaultUniverseDomain = "googleapis.com"
 
 // OAuth2 scopes used by this API.
 const (
@@ -110,7 +109,6 @@ func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, err
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/json-body.want
+++ b/google-api-go-generator/testdata/json-body.want
@@ -92,7 +92,6 @@ const apiVersion = "v1"
 const basePath = "https://ml.googleapis.com/"
 const basePathTemplate = "https://ml.UNIVERSE_DOMAIN/"
 const mtlsBasePath = "https://ml.mtls.googleapis.com/"
-const defaultUniverseDomain = "googleapis.com"
 
 // OAuth2 scopes used by this API.
 const (
@@ -110,7 +109,6 @@ func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, err
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/mapofany.want
+++ b/google-api-go-generator/testdata/mapofany.want
@@ -89,13 +89,11 @@ const apiName = "mapofany"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/mapofarrayofobjects.want
+++ b/google-api-go-generator/testdata/mapofarrayofobjects.want
@@ -89,13 +89,11 @@ const apiName = "additionalprops"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/mapofint64strings.want
+++ b/google-api-go-generator/testdata/mapofint64strings.want
@@ -89,13 +89,11 @@ const apiName = "androidbuildinternal"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/mapofobjects.want
+++ b/google-api-go-generator/testdata/mapofobjects.want
@@ -89,13 +89,11 @@ const apiName = "additionalpropsobjs"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/mapofstrings-1.want
+++ b/google-api-go-generator/testdata/mapofstrings-1.want
@@ -89,13 +89,11 @@ const apiName = "additionalprops"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/param-rename.want
+++ b/google-api-go-generator/testdata/param-rename.want
@@ -89,13 +89,11 @@ const apiName = "paramrename"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/quotednum.want
+++ b/google-api-go-generator/testdata/quotednum.want
@@ -92,7 +92,6 @@ const apiVersion = "v1.1"
 const basePath = "https://www.googleapis.com/adexchangebuyer/v1.1/"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/adexchangebuyer/v1.1/"
 const mtlsBasePath = "https://www.mtls.googleapis.com/adexchangebuyer/v1.1/"
-const defaultUniverseDomain = "googleapis.com"
 
 // OAuth2 scopes used by this API.
 const (
@@ -110,7 +109,6 @@ func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, err
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/repeated.want
+++ b/google-api-go-generator/testdata/repeated.want
@@ -89,13 +89,11 @@ const apiName = "repeated"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/required-query.want
+++ b/google-api-go-generator/testdata/required-query.want
@@ -89,13 +89,11 @@ const apiName = "tshealth"
 const apiVersion = ""
 const basePath = "https://www.googleapis.com/_ah/api/tshealth/v1/"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/_ah/api/tshealth/v1/"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/resource-named-service.want
+++ b/google-api-go-generator/testdata/resource-named-service.want
@@ -92,7 +92,6 @@ const apiVersion = "v1"
 const basePath = "https://appengine.googleapis.com/"
 const basePathTemplate = "https://appengine.UNIVERSE_DOMAIN/"
 const mtlsBasePath = "https://appengine.mtls.googleapis.com/"
-const defaultUniverseDomain = "googleapis.com"
 
 // OAuth2 scopes used by this API.
 const (
@@ -110,7 +109,6 @@ func NewService(ctx context.Context, opts ...option.ClientOption) (*APIService, 
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/unfortunatedefaults.want
+++ b/google-api-go-generator/testdata/unfortunatedefaults.want
@@ -89,13 +89,11 @@ const apiName = "wrapnewlines"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/variants.want
+++ b/google-api-go-generator/testdata/variants.want
@@ -89,13 +89,11 @@ const apiName = "additionalpropsobjs"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/testdata/wrapnewlines.want
+++ b/google-api-go-generator/testdata/wrapnewlines.want
@@ -89,13 +89,11 @@ const apiName = "wrapnewlines"
 const apiVersion = "v1"
 const basePath = "https://www.googleapis.com/discovery/v1/apis"
 const basePathTemplate = "https://www.UNIVERSE_DOMAIN/discovery/v1/apis"
-const defaultUniverseDomain = "googleapis.com"
 
 // NewService creates a new Service.
 func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
-	opts = append(opts, internaloption.WithDefaultUniverseDomain(defaultUniverseDomain))
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
refs: #2335
refs: https://github.com/googleapis/google-cloud-go/pull/9663/commits/dbb73d85295ce84eb4eb2ce45a827ea1bcd6e214