### PR TITLE
fix(internal): set scopes for new auth flow

### DIFF
--- a/idtoken/integration_test.go
+++ b/idtoken/integration_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/idtoken"
 	"google.golang.org/api/option"
@@ -49,28 +48,7 @@ func TestNewTokenSource(t *testing.T) {
 	}
 }
 
-func TestNewClient_WithCredentialFile(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-	client, err := idtoken.NewClient(context.Background(), aud, option.WithCredentialsFile(os.Getenv(envCredentialFile)))
-	if err != nil {
-		t.Fatalf("unable to create Client: %v", err)
-	}
-	tok, err := client.Transport.(*oauth2.Transport).Source.Token()
-	if err != nil {
-		t.Fatalf("unable to retrieve Token: %v", err)
-	}
-	validTok, err := idtoken.Validate(context.Background(), tok.AccessToken, aud)
-	if err != nil {
-		t.Fatalf("token validation failed: %v", err)
-	}
-	if validTok.Audience != aud {
-		t.Fatalf("got %q, want %q", validTok.Audience, aud)
-	}
-}
-
-func TestNewClient_WithCredentialJSON(t *testing.T) {
+func TestNewTokenSource_WithCredentialJSON(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -79,13 +57,18 @@ func TestNewClient_WithCredentialJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to find default creds: %v", err)
 	}
-	client, err := idtoken.NewClient(ctx, aud, option.WithCredentialsJSON(creds.JSON))
+	ts, err := idtoken.NewTokenSource(ctx, aud, option.WithCredentialsJSON(creds.JSON))
 	if err != nil {
 		t.Fatalf("unable to create Client: %v", err)
 	}
-	tok, err := client.Transport.(*oauth2.Transport).Source.Token()
+	tok, err := ts.Token()
 	if err != nil {
 		t.Fatalf("unable to retrieve Token: %v", err)
+	}
+	req := &http.Request{Header: make(http.Header)}
+	tok.SetAuthHeader(req)
+	if !strings.HasPrefix(req.Header.Get("Authorization"), "Bearer ") {
+		t.Fatalf("token should sign requests with Bearer Authorization header")
 	}
 	validTok, err := idtoken.Validate(context.Background(), tok.AccessToken, aud)
 	if err != nil {

--- a/internal/creds.go
+++ b/internal/creds.go
@@ -64,12 +64,16 @@ func credsNewAuth(ctx context.Context, settings *DialSettings) (*google.Credenti
 		useSelfSignedJWT = true
 	}
 
+	if len(settings.Scopes) > 0 {
+		scopes = make([]string, len(settings.Scopes))
+		copy(scopes, settings.Scopes)
+	}
 	if len(settings.Audiences) > 0 {
 		aud = settings.Audiences[0]
 	}
 	// Only default scopes if user did not also set an audience.
 	if len(settings.Scopes) == 0 && aud == "" && len(settings.DefaultScopes) > 0 {
-		scopes = make([]string, len(scopes))
+		scopes = make([]string, len(settings.DefaultScopes))
 		copy(scopes, settings.DefaultScopes)
 	}
 	if len(scopes) == 0 && aud == "" {


### PR DESCRIPTION
Also updated a test that relied on impl specific types before. Testing the TokenSource methods instead of NewClient as NewClient defers impl to NewTokenSource anyways.

Fixes: #2523
Fixes: #2522