### PR TITLE
chore(deps): disable otel updates until Go 1.21

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,10 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["^github.com/google/go-github/v"],
+      "matchPackagePatterns": [
+        "^github.com/google/go-github/v",
+        "^go.opentelemetry.io/contrib/instrumentation/",
+      ],
       "enabled": false
     }
   ],


### PR DESCRIPTION
Fixes incorrect renovate config field `matchingPackageNames` -> `matchingPackagePatterns`.

Disables otel instrumentation updates b.c they require Go 1.21.