### PR TITLE
[DON'T LAND YET]Allow setting up availabilityDomain in Scheduling object

### DIFF
--- a/compute/v1/compute-api.json
+++ b/compute/v1/compute-api.json
@@ -58332,6 +58332,11 @@
           "description": "Specifies whether the instance should be automatically restarted if it is terminated by Compute Engine (not terminated by a user). You can only set the automatic restart option for standard instances. Preemptible instances cannot be automatically restarted. By default, this is set to true so an instance is automatically restarted if it is terminated by Compute Engine.",
           "type": "boolean"
         },
+        "availabilityDomain": {
+          "description": "Specifies the availability domain (AD), which this instance should be scheduled on. The AD belongs to the spread GroupPlacementPolicy resource policy that has been assigned to the instance. Specify a value between 1-max count of availability domains in your GroupPlacementPolicy. See go/placement-policy-extension for more details.",
+          "format": "int32",
+          "type": "integer"
+        },
         "instanceTerminationAction": {
           "description": "Specifies the termination action for the instance.",
           "enum": [


### PR DESCRIPTION
This is for creating internal patch, please don't land.

Allow setting up the availability domain in the scheduling message. So that newly spawned cloud hosts can have the domain set up. The scheduling structure currently includes availability domain in the alpha API but not yet in production. We need to enable the setup of availability domain in launching instance requests to unblock the use of GCP placement groups.