### PR TITLE
fix(option): skip nil bytes for CredentialsJSON

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -65,6 +65,9 @@ func WithCredentialsJSON(p []byte) ClientOption {
 type withCredentialsJSON []byte
 
 func (w withCredentialsJSON) Apply(o *internal.DialSettings) {
+	if w == nil {
+		return
+	}
 	o.CredentialsJSON = make([]byte, len(w))
 	copy(o.CredentialsJSON, w)
 }

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -5,10 +5,9 @@
 package option
 
 import (
-	"testing"
-
 	"crypto/tls"
 	"math/big"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -132,4 +131,34 @@ func TestApplyClientCertSource(t *testing.T) {
 	if !cmp.Equal(certGot, certWant, cmpopts.IgnoreUnexported(big.Int{}), cmpopts.IgnoreFields(tls.Certificate{}, "Leaf")) {
 		t.Errorf(cmp.Diff(certGot, certWant, cmpopts.IgnoreUnexported(big.Int{}), cmpopts.IgnoreFields(tls.Certificate{}, "Leaf")))
 	}
+}
+
+func TestCredentialsJSON(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var got internal.DialSettings
+
+		WithCredentialsJSON(nil).Apply(&got)
+
+		want := internal.DialSettings{
+			CredentialsJSON: nil,
+		}
+
+		if !cmp.Equal(got, want) {
+			t.Errorf(cmp.Diff(got, want))
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		var got internal.DialSettings
+
+		WithCredentialsJSON([]byte{}).Apply(&got)
+
+		want := internal.DialSettings{
+			CredentialsJSON: []byte{},
+		}
+
+		if !cmp.Equal(got, want) {
+			t.Errorf(cmp.Diff(got, want))
+		}
+	})
 }


### PR DESCRIPTION
Closes https://github.com/googleapis/google-api-go-client/issues/2647
Nil bytes was treated to empty bytes, which causes failure on empty JSON. 
I think we can improve this by ignoring nil bytes.