### PR TITLE
fix(gensupport): wrap chunk upload err for retries

### DIFF
--- a/internal/gensupport/resumable.go
+++ b/internal/gensupport/resumable.go
@@ -171,6 +171,10 @@ func (rx *ResumableUpload) Upload(ctx context.Context) (resp *http.Response, err
 			if resp != nil && resp.Body != nil {
 				resp.Body.Close()
 			}
+			// If there were retries, indicate this in the error message and wrap the final error.
+			if rx.attempts > 1 {
+				return nil, fmt.Errorf("chunk upload failed after %d attempts;, final error: %w", rx.attempts, err)
+			}
 			return nil, err
 		}
 		// This case is very unlikely but possible only if rx.ChunkRetryDeadline is


### PR DESCRIPTION
This makes it easier to debug whether and/or how many retries happened before a failure with a chunk upload.