### PR TITLE
fix(transport/grpc): retain UserAgent option with new auth stack

### DIFF
--- a/transport/grpc/dial.go
+++ b/transport/grpc/dial.go
@@ -53,6 +53,9 @@ var logRateLimiter = rate.Sometimes{Interval: 1 * time.Second}
 // Assign to var for unit test replacement
 var dialContext = grpc.DialContext
 
+// Assign to var for unit test replacement
+var dialContextNewAuth = grpctransport.Dial
+
 // otelStatsHandler is a singleton otelgrpc.clientHandler to be used across
 // all dial connections to avoid the memory leak documented in
 // https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4226
@@ -218,7 +221,7 @@ func dialPoolNewAuth(ctx context.Context, secure bool, poolSize int, ds *interna
 		defaultEndpointTemplate = ds.DefaultEndpoint
 	}
 
-	pool, err := grpctransport.Dial(ctx, secure, &grpctransport.Options{
+	pool, err := dialContextNewAuth(ctx, secure, &grpctransport.Options{
 		DisableTelemetry:      ds.TelemetryDisabled,
 		DisableAuthentication: ds.NoAuth,
 		Endpoint:              ds.Endpoint,

--- a/transport/grpc/dial.go
+++ b/transport/grpc/dial.go
@@ -223,7 +223,7 @@ func dialPoolNewAuth(ctx context.Context, secure bool, poolSize int, ds *interna
 		DisableAuthentication: ds.NoAuth,
 		Endpoint:              ds.Endpoint,
 		Metadata:              metadata,
-		GRPCDialOpts:          ds.GRPCDialOpts,
+		GRPCDialOpts:          prepareDialOptsNewAuth(ds),
 		PoolSize:              poolSize,
 		Credentials:           creds,
 		APIKey:                ds.APIKey,
@@ -246,6 +246,15 @@ func dialPoolNewAuth(ctx context.Context, secure bool, poolSize int, ds *interna
 		},
 	})
 	return pool, err
+}
+
+func prepareDialOptsNewAuth(ds *internal.DialSettings) []grpc.DialOption {
+	var opts []grpc.DialOption
+	if ds.UserAgent != "" {
+		opts = append(opts, grpc.WithUserAgent(ds.UserAgent))
+	}
+
+	return append(opts, ds.GRPCDialOpts...)
 }
 
 func dial(ctx context.Context, insecure bool, o *internal.DialSettings) (*grpc.ClientConn, error) {

--- a/transport/grpc/dial_test.go
+++ b/transport/grpc/dial_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"cloud.google.com/go/auth/grpctransport"
 	"cloud.google.com/go/compute/metadata"
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/oauth2/google"
@@ -33,6 +34,45 @@ func TestDial(t *testing.T) {
 
 	var o internal.DialSettings
 	dial(context.Background(), false, &o)
+}
+
+func TestDialPoolNewAuthDialOptions(t *testing.T) {
+	oldDialContextNewAuth := dialContextNewAuth
+	var wantNumOpts int
+	// Replace package var in order to assert DialContext args.
+	dialContextNewAuth = func(ctx context.Context, secure bool, opts *grpctransport.Options) (grpctransport.GRPCClientConnPool, error) {
+		if len(opts.GRPCDialOpts) != wantNumOpts {
+			t.Fatalf("got: %d, want: %d", len(opts.GRPCDialOpts), wantNumOpts)
+		}
+		return nil, nil
+	}
+	defer func() {
+		dialContextNewAuth = oldDialContextNewAuth
+	}()
+
+	for _, testcase := range []struct {
+		name        string
+		ds          *internal.DialSettings
+		wantNumOpts int
+	}{
+		{
+			name:        "no dial options",
+			ds:          &internal.DialSettings{},
+			wantNumOpts: 0,
+		},
+		{
+			name: "with user agent",
+			ds: &internal.DialSettings{
+				UserAgent: "test",
+			},
+			wantNumOpts: 1,
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			wantNumOpts = testcase.wantNumOpts
+			dialPoolNewAuth(context.Background(), false, 1, testcase.ds)
+		})
+	}
 }
 
 func TestPrepareDialOptsNewAuth(t *testing.T) {

--- a/transport/grpc/dial_test.go
+++ b/transport/grpc/dial_test.go
@@ -35,6 +35,34 @@ func TestDial(t *testing.T) {
 	dial(context.Background(), false, &o)
 }
 
+func TestPrepareDialOptsNewAuth(t *testing.T) {
+	for _, testcase := range []struct {
+		name        string
+		ds          *internal.DialSettings
+		wantNumOpts int
+	}{
+		{
+			name:        "empty",
+			ds:          &internal.DialSettings{},
+			wantNumOpts: 0,
+		},
+		{
+			name: "user agent",
+			ds: &internal.DialSettings{
+				UserAgent: "test",
+			},
+			wantNumOpts: 1,
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			got := prepareDialOptsNewAuth(testcase.ds)
+			if len(got) != testcase.wantNumOpts {
+				t.Fatalf("got %d options, want %d options", len(got), testcase.wantNumOpts)
+			}
+		})
+	}
+}
+
 func TestCheckDirectPathEndPoint(t *testing.T) {
 	for _, testcase := range []struct {
 		name     string


### PR DESCRIPTION
The only code that converted the `option.WithUserAgent` to a gRPC DialOption `WithUserAgent` was in the `dial` function, which was bypassed when leveraging the new auth library that handles most of the important dialing set up re:credentials.

To fix this, I added a new helper specifically for use in `dialPoolNewAuth` that prepares dial options based on the given `DialSettings` - `prepareDialOpionsNewAuth`. I could've added the same logic to anywhere in `dialPoolNewAuth` to fix it, but I felt I needed to signal that this is the method to be modifying gRPC DialOptions in so that in the future, we can centralize further gRPC DialOption manipulation rather than just "wherever" like in the "old" `dial`.

Also stored the `grpctransport.Dial` function into a global variable so that unit tests could spoof it to check on the gRPC DialOptions that were provided - just like the "old" `dial` did for testing.

Updates https://github.com/googleapis/google-cloud-go/issues/10550 but needs to be released here, integrated there, and released there.