### PR TITLE
feat: move storage, bigquery, and compute to new auth lib

### DIFF
--- a/bigquery/v2/bigquery-gen.go
+++ b/bigquery/v2/bigquery-gen.go
@@ -145,6 +145,7 @@ func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, err
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
+	opts = append(opts, internaloption.EnableNewAuthLibrary())
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/compute/v0.alpha/compute-gen.go
+++ b/compute/v0.alpha/compute-gen.go
@@ -137,6 +137,7 @@ func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, err
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
+	opts = append(opts, internaloption.EnableNewAuthLibrary())
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/compute/v0.beta/compute-gen.go
+++ b/compute/v0.beta/compute-gen.go
@@ -137,6 +137,7 @@ func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, err
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
+	opts = append(opts, internaloption.EnableNewAuthLibrary())
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/compute/v1/compute-gen.go
+++ b/compute/v1/compute-gen.go
@@ -137,6 +137,7 @@ func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, err
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
+	opts = append(opts, internaloption.EnableNewAuthLibrary())
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -81,15 +81,6 @@ var skipAPIGeneration = map[string]bool{
 	"datalineage:v1":       true,
 }
 
-// skipNewAuthLibrary is a set of APIs to not migrate to cloud.google.com/go/auth.
-var skipNewAuthLibrary = map[string]bool{
-	"bigquery:v2":   true,
-	"compute:alpha": true,
-	"compute:beta":  true,
-	"compute:v1":    true,
-	"storage:v1":    true,
-}
-
 var apisToSplit = map[string]bool{
 	"compute": true,
 }
@@ -897,9 +888,8 @@ func (a *API) GenerateCode() ([]byte, error) {
 	if a.mtlsAPIBaseURL() != "" {
 		pn("opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))")
 	}
-	if !skipNewAuthLibrary[a.ID] {
-		pn("opts = append(opts, internaloption.EnableNewAuthLibrary())")
-	}
+	pn("opts = append(opts, internaloption.EnableNewAuthLibrary())")
+
 	pn("client, endpoint, err := htransport.NewClient(ctx, opts...)")
 	pn("if err != nil { return nil, err }")
 	pn("s, err := New(client)")

--- a/storage/v1/storage-gen.go
+++ b/storage/v1/storage-gen.go
@@ -133,6 +133,7 @@ func NewService(ctx context.Context, opts ...option.ClientOption) (*Service, err
 	opts = append(opts, internaloption.WithDefaultEndpoint(basePath))
 	opts = append(opts, internaloption.WithDefaultEndpointTemplate(basePathTemplate))
 	opts = append(opts, internaloption.WithDefaultMTLSEndpoint(mtlsBasePath))
+	opts = append(opts, internaloption.EnableNewAuthLibrary())
 	client, endpoint, err := htransport.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
All other clients in this repo have been exercising the new library
for almost 3 months now. I believe things to be stable so we should
move the remaining libraries.