### PR TITLE
fix(idtoken): include email in Payload

### DIFF
--- a/idtoken/validate.go
+++ b/idtoken/validate.go
@@ -50,6 +50,7 @@ type Payload struct {
 	Expires  int64                  `json:"exp"`
 	IssuedAt int64                  `json:"iat"`
 	Subject  string                 `json:"sub,omitempty"`
+	Email    string                 `json:"email,omitempty`
 	Claims   map[string]interface{} `json:"-"`
 }
 


### PR DESCRIPTION
The Payload type was missing the email field, which is useful when validating IAP JWTs, in order to dissuade using the x-goog-authenticated-user-email header. Unclear to me why it was originally omitted.