### PR TITLE
fix: reference gax import in storage libs

### DIFF
--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -858,6 +858,9 @@ func (a *API) GenerateCode() ([]byte, error) {
 	pn("var _ = context.Canceled")
 	pn("var _ = internaloption.WithDefaultEndpoint")
 	pn("var _ = internal.Version")
+	if a.Name == "storage" {
+		pn("var _ = gax.Version")
+	}
 	pn("")
 	pn("const apiId = %q", a.doc.ID)
 	pn("const apiName = %q", a.doc.Name)

--- a/storage/v1/storage-gen.go
+++ b/storage/v1/storage-gen.go
@@ -93,6 +93,7 @@ var _ = strings.Replace
 var _ = context.Canceled
 var _ = internaloption.WithDefaultEndpoint
 var _ = internal.Version
+var _ = gax.Version
 
 const apiId = "storage:v1"
 const apiName = "storage"


### PR DESCRIPTION
The storage client is the only client that imports gax. Depending on the RPCs being generated it may or may not use the gax import. To avoid generating an unreferenced lets always import it.

Internal Question: 9036645275644461056