### PR TITLE
fix(transport): restore support for GOOGLE_CLOUD_UNIVERSE_DOMAIN env var

### DIFF
--- a/transport/grpc/dial.go
+++ b/transport/grpc/dial.go
@@ -247,7 +247,7 @@ func dialPoolNewAuth(ctx context.Context, secure bool, poolSize int, ds *interna
 			DefaultScopes:                   ds.DefaultScopes,
 			SkipValidation:                  skipValidation,
 		},
-		UniverseDomain: ds.UniverseDomain,
+		UniverseDomain: ds.GetUniverseDomain(),
 	})
 	return pool, err
 }

--- a/transport/grpc/dial_test.go
+++ b/transport/grpc/dial_test.go
@@ -45,7 +45,8 @@ func TestDialPoolNewAuthDialOptions(t *testing.T) {
 		if len(opts.GRPCDialOpts) != wantNumOpts {
 			t.Fatalf("got: %d, want: %d", len(opts.GRPCDialOpts), wantNumOpts)
 		}
-		if opts.UniverseDomain != universeDomain {
+		// In "no dial options", a blank UniverseDomain should result in the default "googleapis.com", so skip comparison.
+		if universeDomain != "" && opts.UniverseDomain != universeDomain {
 			t.Fatalf("got: %q, want: %q", opts.UniverseDomain, universeDomain)
 		}
 		return nil, nil

--- a/transport/grpc/dial_test.go
+++ b/transport/grpc/dial_test.go
@@ -87,6 +87,25 @@ func TestDialPoolNewAuthDialOptions(t *testing.T) {
 	}
 }
 
+func TestDialPool_NewAuthUniverseDomainEnvVar(t *testing.T) {
+	universeDomain := "example.com"
+	t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", universeDomain)
+
+	// Replace package var in order to assert DialContext args.
+	oldDialContextNewAuth := dialContextNewAuth
+	dialContextNewAuth = func(ctx context.Context, secure bool, opts *grpctransport.Options) (grpctransport.GRPCClientConnPool, error) {
+		if opts.UniverseDomain != universeDomain {
+			t.Fatalf("got: %q, want: %q", opts.UniverseDomain, universeDomain)
+		}
+		return nil, nil
+	}
+	defer func() {
+		dialContextNewAuth = oldDialContextNewAuth
+	}()
+
+	dialPoolNewAuth(context.Background(), false, 1, &internal.DialSettings{})
+}
+
 func TestPrepareDialOptsNewAuth(t *testing.T) {
 	for _, testcase := range []struct {
 		name        string

--- a/transport/http/dial.go
+++ b/transport/http/dial.go
@@ -30,6 +30,9 @@ import (
 	"google.golang.org/api/transport/http/internal/propagation"
 )
 
+// package var for unit test substitution
+var newClient = httptransport.NewClient
+
 // NewClient returns an HTTP client for use communicating with a Google cloud
 // service, configured with the given ClientOptions. It also returns the endpoint
 // for the service as specified in the options.
@@ -107,7 +110,7 @@ func newClientNewAuth(ctx context.Context, base http.RoundTripper, ds *internal.
 	if ds.RequestReason != "" {
 		headers.Set("X-goog-request-reason", ds.RequestReason)
 	}
-	client, err := httptransport.NewClient(&httptransport.Options{
+	client, err := newClient(&httptransport.Options{
 		DisableTelemetry:      ds.TelemetryDisabled,
 		DisableAuthentication: ds.NoAuth,
 		Headers:               headers,
@@ -130,7 +133,7 @@ func newClientNewAuth(ctx context.Context, base http.RoundTripper, ds *internal.
 			DefaultScopes:           ds.DefaultScopes,
 			SkipValidation:          skipValidation,
 		},
-		UniverseDomain: ds.UniverseDomain,
+		UniverseDomain: ds.GetUniverseDomain(),
 	})
 	if err != nil {
 		return nil, err

--- a/transport/http/dial_test.go
+++ b/transport/http/dial_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"testing"
 
 	"cloud.google.com/go/auth/httptransport"
@@ -33,10 +32,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewClient_NewAuthUniverseDomain(t *testing.T) {
-	os.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "example.com")
-	defer func() {
-		os.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "")
-	}()
+	t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "example.com")
 
 	newClient = func(opts *httptransport.Options) (*http.Client, error) {
 		if got, want := opts.UniverseDomain, "example.com"; got != want {

--- a/transport/http/dial_test.go
+++ b/transport/http/dial_test.go
@@ -31,15 +31,22 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
-func TestNewClient_NewAuthUniverseDomain(t *testing.T) {
-	t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "example.com")
+func TestNewClient_NewAuthUniverseDomainEnvVar(t *testing.T) {
+	universeDomain := "example.com"
+	t.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", universeDomain)
 
+	// Replace package var in order to assert DialContext args.
+	oldNewClient := newClient
 	newClient = func(opts *httptransport.Options) (*http.Client, error) {
-		if got, want := opts.UniverseDomain, "example.com"; got != want {
+		if got, want := opts.UniverseDomain, universeDomain; got != want {
 			t.Fatalf("got %s, want: %s", got, want)
 		}
 		return nil, nil
 	}
+	defer func() {
+		newClient = oldNewClient
+	}()
+
 	_, _, err := NewClient(context.Background(), internaloption.EnableNewAuthLibrary())
 	if err != nil {
 		t.Fatalf("unable to create client: %v", err)

--- a/transport/http/dial_test.go
+++ b/transport/http/dial_test.go
@@ -34,7 +34,7 @@ func TestNewClient(t *testing.T) {
 
 func TestNewClient_NewAuthUniverseDomain(t *testing.T) {
 	os.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "example.com")
-	defer func(){
+	defer func() {
 		os.Setenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN", "")
 	}()
 


### PR DESCRIPTION
The `GOOGLE_CLOUD_UNIVERSE_DOMAIN `env variable no longer works.

If I use `google.golang.org/api@v0.191.0` I can start my example with `GOOGLE_CLOUD_UNIVERSE_DOMAIN=example.com` and it works without specifying `WithUniverseDomain` option explicitly.

When I use `google.golang.org/api@v0.197.0` and `cloud.google.com/go/auth@v0.9.4` I get error when I am using this env, if I don't specify `WithUniverseDomain` explicitly.

Error: the configured universe domain ("googleapis.com") does not match the universe domain found in the credentials ("example.com"). If you haven't configured the universe domain explicitly, "googleapis.com" is the default