### PR TITLE
feat(option/internaloption): add WithDefaultMTLSEndpointTemplate

### DIFF
--- a/internal/settings.go
+++ b/internal/settings.go
@@ -35,6 +35,7 @@ type DialSettings struct {
 	DefaultEndpoint               string
 	DefaultEndpointTemplate       string
 	DefaultMTLSEndpoint           string
+	DefaultMTLSEndpointTemplate   string
 	Scopes                        []string
 	DefaultScopes                 []string
 	EnableJwtWithScope            bool

--- a/option/internaloption/internaloption.go
+++ b/option/internaloption/internaloption.go
@@ -57,11 +57,34 @@ func (o defaultMTLSEndpointOption) Apply(settings *internal.DialSettings) {
 	settings.DefaultMTLSEndpoint = string(o)
 }
 
-// WithDefaultMTLSEndpoint is an option that indicates the default mTLS endpoint.
+// WithDefaultMTLSEndpoint is an option that indicates the default mTLS
+// endpoint.
 //
 // It should only be used internally by generated clients.
+//
+// Deprecated: WithDefaultMTLSEndpoint does not support setting the universe
+// domain. Use WithDefaultMTLSEndpointTemplate and WithDefaultUniverseDomain to
+// compose the default endpoint instead.
 func WithDefaultMTLSEndpoint(url string) option.ClientOption {
 	return defaultMTLSEndpointOption(url)
+}
+
+type defaultMTLSEndpointTemplateOption string
+
+func (o defaultMTLSEndpointTemplateOption) Apply(settings *internal.DialSettings) {
+	settings.DefaultMTLSEndpointTemplate = string(o)
+}
+
+// WithDefaultMTLSEndpointTemplate provides a template for creating the default
+// mTLS endpoint using a universe domain. See also WithDefaultUniverseDomain and
+// option.WithUniverseDomain. The placeholder UNIVERSE_DOMAIN should be used
+// instead of a concrete universe domain such as "googleapis.com".
+//
+// Example: WithDefaultMTLSEndpointTemplate("https://mtls.UNIVERSE_DOMAIN")
+//
+// It should only be used internally by generated clients.
+func WithDefaultMTLSEndpointTemplate(url string) option.ClientOption {
+	return defaultMTLSEndpointTemplateOption(url)
 }
 
 // SkipDialSettingsValidation bypasses validation on ClientOptions.

--- a/option/internaloption/internaloption_test.go
+++ b/option/internaloption/internaloption_test.go
@@ -37,6 +37,7 @@ func TestDefaultApply(t *testing.T) {
 		WithDefaultEndpoint("https://example.com:443"),
 		WithDefaultEndpointTemplate("https://foo.UNIVERSE_DOMAIN/"),
 		WithDefaultMTLSEndpoint("http://mtls.example.com:445"),
+		WithDefaultMTLSEndpointTemplate("http://mtls.UNIVERSE_DOMAIN:445"),
 		WithDefaultScopes("a"),
 		WithDefaultUniverseDomain("foo.com"),
 		WithDefaultAudience("audience"),
@@ -46,12 +47,13 @@ func TestDefaultApply(t *testing.T) {
 		opt.Apply(&got)
 	}
 	want := internal.DialSettings{
-		DefaultScopes:           []string{"a"},
-		DefaultEndpoint:         "https://example.com:443",
-		DefaultEndpointTemplate: "https://foo.UNIVERSE_DOMAIN/",
-		DefaultUniverseDomain:   "foo.com",
-		DefaultAudience:         "audience",
-		DefaultMTLSEndpoint:     "http://mtls.example.com:445",
+		DefaultScopes:               []string{"a"},
+		DefaultEndpoint:             "https://example.com:443",
+		DefaultEndpointTemplate:     "https://foo.UNIVERSE_DOMAIN/",
+		DefaultUniverseDomain:       "foo.com",
+		DefaultAudience:             "audience",
+		DefaultMTLSEndpoint:         "http://mtls.example.com:445",
+		DefaultMTLSEndpointTemplate: "http://mtls.UNIVERSE_DOMAIN:445",
 	}
 	ignore := []cmp.Option{
 		cmpopts.IgnoreUnexported(grpc.ClientConn{}),


### PR DESCRIPTION
* Add DefaultMTLSEndpointTemplate to internal/settings.go
* Deprecate internaloption.WithDefaultMTLSEndpoint