### PR TITLE
fix(gensupport): context cancel error check

### DIFF
--- a/internal/gensupport/resumable.go
+++ b/internal/gensupport/resumable.go
@@ -266,7 +266,7 @@ func (rx *ResumableUpload) Upload(ctx context.Context) (resp *http.Response, err
 			// The upload should be retried if the rCtx is canceled due to a timeout.
 			select {
 			case <-rCtx.Done():
-				if errors.Is(rCtx.Err(), context.DeadlineExceeded) {
+				if rx.ChunkTransferTimeout != 0 && errors.Is(rCtx.Err(), context.DeadlineExceeded) {
 					// Cancel the context for rCtx
 					cancel()
 					continue


### PR DESCRIPTION
Previously, if an rCtx wasn't created with chunkTransferTimeout and the parent context had a timeout, calling cancel under the same conditions caused a crash due to invalid memory access. This occurred if the parent context's timeout was triggered.








