### PR TITLE
Fix: Propagate context to HTTP requests in generated code to enable APM tracing

### DIFF
--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -2330,7 +2330,7 @@ func (meth *Method) generateCode() {
 		bodyArg = "newBody"
 	}
 	pn(`urls += "?" + c.urlParams_.Encode()`)
-	pn("req, err := http.NewRequest(%q, urls, %s)", httpMethod, bodyArg)
+	pn("req, err := http.NewRequestWithContext(c.ctx_, %q, urls, %s)", httpMethod, bodyArg)
 	pn("if err != nil { return nil, err }")
 	pn("req.Header = reqHeaders")
 	if meth.supportsMediaUpload() {

--- a/google-api-go-generator/testdata/any.want
+++ b/google-api-go-generator/testdata/any.want
@@ -759,7 +759,7 @@ func (c *ProjectsLogServicesListCall) doRequest(alt string) (*http.Response, err
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logServices")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -944,7 +944,7 @@ func (c *ProjectsLogServicesIndexesListCall) doRequest(alt string) (*http.Respon
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logServices/{logServicesId}/indexes")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1074,7 +1074,7 @@ func (c *ProjectsLogServicesSinksCreateCall) doRequest(alt string) (*http.Respon
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logServices/{logServicesId}/sinks")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1178,7 +1178,7 @@ func (c *ProjectsLogServicesSinksDeleteCall) doRequest(alt string) (*http.Respon
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logServices/{logServicesId}/sinks/{sinksId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1295,7 +1295,7 @@ func (c *ProjectsLogServicesSinksGetCall) doRequest(alt string) (*http.Response,
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logServices/{logServicesId}/sinks/{sinksId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1410,7 +1410,7 @@ func (c *ProjectsLogServicesSinksListCall) doRequest(alt string) (*http.Response
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logServices/{logServicesId}/sinks")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1521,7 +1521,7 @@ func (c *ProjectsLogServicesSinksUpdateCall) doRequest(alt string) (*http.Respon
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logServices/{logServicesId}/sinks/{sinksId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("PUT", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "PUT", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1624,7 +1624,7 @@ func (c *ProjectsLogsDeleteCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logs/{logsId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1775,7 +1775,7 @@ func (c *ProjectsLogsListCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logs")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1910,7 +1910,7 @@ func (c *ProjectsLogsEntriesWriteCall) doRequest(alt string) (*http.Response, er
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logs/{logsId}/entries:write")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2018,7 +2018,7 @@ func (c *ProjectsLogsSinksCreateCall) doRequest(alt string) (*http.Response, err
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logs/{logsId}/sinks")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2122,7 +2122,7 @@ func (c *ProjectsLogsSinksDeleteCall) doRequest(alt string) (*http.Response, err
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logs/{logsId}/sinks/{sinksId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2239,7 +2239,7 @@ func (c *ProjectsLogsSinksGetCall) doRequest(alt string) (*http.Response, error)
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logs/{logsId}/sinks/{sinksId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2353,7 +2353,7 @@ func (c *ProjectsLogsSinksListCall) doRequest(alt string) (*http.Response, error
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logs/{logsId}/sinks")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2464,7 +2464,7 @@ func (c *ProjectsLogsSinksUpdateCall) doRequest(alt string) (*http.Response, err
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta3/projects/{projectsId}/logs/{logsId}/sinks/{sinksId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("PUT", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "PUT", urls, body)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/blogger-3.want
+++ b/google-api-go-generator/testdata/blogger-3.want
@@ -1340,7 +1340,7 @@ func (c *BlogUserInfosGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "users/{userId}/blogs/{blogId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1457,7 +1457,7 @@ func (c *BlogsGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1565,7 +1565,7 @@ func (c *BlogsGetByUrlCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/byurl")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1691,7 +1691,7 @@ func (c *BlogsListByUserCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "users/{userId}/blogs")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1794,7 +1794,7 @@ func (c *CommentsApproveCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}/comments/{commentId}/approve")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1899,7 +1899,7 @@ func (c *CommentsDeleteCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}/comments/{commentId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1992,7 +1992,7 @@ func (c *CommentsGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}/comments/{commentId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2166,7 +2166,7 @@ func (c *CommentsListCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}/comments")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2333,7 +2333,7 @@ func (c *CommentsListByBlogCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/comments")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2457,7 +2457,7 @@ func (c *CommentsMarkAsSpamCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}/comments/{commentId}/spam")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2562,7 +2562,7 @@ func (c *CommentsRemoveContentCall) doRequest(alt string) (*http.Response, error
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}/comments/{commentId}/removecontent")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2685,7 +2685,7 @@ func (c *PageViewsGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/pageviews")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2785,7 +2785,7 @@ func (c *PagesDeleteCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/pages/{pageId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2886,7 +2886,7 @@ func (c *PagesGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/pages/{pageId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2990,7 +2990,7 @@ func (c *PagesInsertCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/pages")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3131,7 +3131,7 @@ func (c *PagesListCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/pages")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3237,7 +3237,7 @@ func (c *PagesPatchCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/pages/{pageId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("PATCH", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "PATCH", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3344,7 +3344,7 @@ func (c *PagesUpdateCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/pages/{pageId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("PUT", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "PUT", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3468,7 +3468,7 @@ func (c *PostUserInfosGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "users/{userId}/blogs/{blogId}/posts/{postId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3660,7 +3660,7 @@ func (c *PostUserInfosListCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "users/{userId}/blogs/{blogId}/posts")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3783,7 +3783,7 @@ func (c *PostsDeleteCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3891,7 +3891,7 @@ func (c *PostsGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4022,7 +4022,7 @@ func (c *PostsGetByPathCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/bypath")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4132,7 +4132,7 @@ func (c *PostsInsertCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4326,7 +4326,7 @@ func (c *PostsListCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4453,7 +4453,7 @@ func (c *PostsPatchCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("PATCH", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "PATCH", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4561,7 +4561,7 @@ func (c *PostsPublishCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}/publish")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4662,7 +4662,7 @@ func (c *PostsRevertCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}/revert")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4793,7 +4793,7 @@ func (c *PostsSearchCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/search")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4899,7 +4899,7 @@ func (c *PostsUpdateCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "blogs/{blogId}/posts/{postId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("PUT", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "PUT", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -5009,7 +5009,7 @@ func (c *UsersGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "users/{userId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/getwithoutbody.want
+++ b/google-api-go-generator/testdata/getwithoutbody.want
@@ -282,7 +282,7 @@ func (c *MetricDescriptorsListCall) doRequest(alt string) (*http.Response, error
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "{project}/metricDescriptors")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/http-body.want
+++ b/google-api-go-generator/testdata/http-body.want
@@ -343,7 +343,7 @@ func (c *ProjectsLocationsDatasetsFhirStoresFhirCreateResourceCall) doRequest(al
 	}
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta1/{+parent}/fhir/{+type}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +441,7 @@ func (c *ProjectsLocationsDatasetsFhirStoresFhirReadCall) doRequest(alt string) 
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/json-body.want
+++ b/google-api-go-generator/testdata/json-body.want
@@ -2464,7 +2464,7 @@ func (c *ProjectsGetConfigCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}:getConfig")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2573,7 +2573,7 @@ func (c *ProjectsPredictCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}:predict")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2684,7 +2684,7 @@ func (c *ProjectsJobsCancelCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}:cancel")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2788,7 +2788,7 @@ func (c *ProjectsJobsCreateCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+parent}/jobs")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2898,7 +2898,7 @@ func (c *ProjectsJobsGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3013,7 +3013,7 @@ func (c *ProjectsJobsGetIamPolicyCall) doRequest(alt string) (*http.Response, er
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:getIamPolicy")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3164,7 +3164,7 @@ func (c *ProjectsJobsListCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+parent}/jobs")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3322,7 +3322,7 @@ func (c *ProjectsJobsPatchCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("PATCH", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "PATCH", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3430,7 +3430,7 @@ func (c *ProjectsJobsSetIamPolicyCall) doRequest(alt string) (*http.Response, er
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:setIamPolicy")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3546,7 +3546,7 @@ func (c *ProjectsJobsTestIamPermissionsCall) doRequest(alt string) (*http.Respon
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:testIamPermissions")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3658,7 +3658,7 @@ func (c *ProjectsLocationsGetCall) doRequest(alt string) (*http.Response, error)
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3793,7 +3793,7 @@ func (c *ProjectsLocationsListCall) doRequest(alt string) (*http.Response, error
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+parent}/locations")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3924,7 +3924,7 @@ func (c *ProjectsModelsCreateCall) doRequest(alt string) (*http.Response, error)
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+parent}/models")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4028,7 +4028,7 @@ func (c *ProjectsModelsDeleteCall) doRequest(alt string) (*http.Response, error)
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4141,7 +4141,7 @@ func (c *ProjectsModelsGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4256,7 +4256,7 @@ func (c *ProjectsModelsGetIamPolicyCall) doRequest(alt string) (*http.Response, 
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:getIamPolicy")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4403,7 +4403,7 @@ func (c *ProjectsModelsListCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+parent}/models")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4557,7 +4557,7 @@ func (c *ProjectsModelsPatchCall) doRequest(alt string) (*http.Response, error) 
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("PATCH", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "PATCH", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4665,7 +4665,7 @@ func (c *ProjectsModelsSetIamPolicyCall) doRequest(alt string) (*http.Response, 
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:setIamPolicy")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4781,7 +4781,7 @@ func (c *ProjectsModelsTestIamPermissionsCall) doRequest(alt string) (*http.Resp
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:testIamPermissions")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4899,7 +4899,7 @@ func (c *ProjectsModelsVersionsCreateCall) doRequest(alt string) (*http.Response
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+parent}/versions")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -5006,7 +5006,7 @@ func (c *ProjectsModelsVersionsDeleteCall) doRequest(alt string) (*http.Response
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -5123,7 +5123,7 @@ func (c *ProjectsModelsVersionsGetCall) doRequest(alt string) (*http.Response, e
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -5268,7 +5268,7 @@ func (c *ProjectsModelsVersionsListCall) doRequest(alt string) (*http.Response, 
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+parent}/versions")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -5418,7 +5418,7 @@ func (c *ProjectsModelsVersionsPatchCall) doRequest(alt string) (*http.Response,
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("PATCH", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "PATCH", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -5535,7 +5535,7 @@ func (c *ProjectsModelsVersionsSetDefaultCall) doRequest(alt string) (*http.Resp
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}:setDefault")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -5645,7 +5645,7 @@ func (c *ProjectsOperationsCancelCall) doRequest(alt string) (*http.Response, er
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}:cancel")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -5749,7 +5749,7 @@ func (c *ProjectsOperationsDeleteCall) doRequest(alt string) (*http.Response, er
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -5863,7 +5863,7 @@ func (c *ProjectsOperationsGetCall) doRequest(alt string) (*http.Response, error
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -6006,7 +6006,7 @@ func (c *ProjectsOperationsListCall) doRequest(alt string) (*http.Response, erro
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}/operations")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/mapofarrayofobjects.want
+++ b/google-api-go-generator/testdata/mapofarrayofobjects.want
@@ -236,7 +236,7 @@ func (c *AtlasGetMapCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "map")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/mapofstrings-1.want
+++ b/google-api-go-generator/testdata/mapofstrings-1.want
@@ -233,7 +233,7 @@ func (c *AtlasGetMapCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "map")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/mapprotostruct.want
+++ b/google-api-go-generator/testdata/mapprotostruct.want
@@ -209,7 +209,7 @@ func (c *AtlasGetMapCall) doRequest(alt string) (*http.Response, error) {
 	body := bytes.NewReader(protoBytes)
 	urls := googleapi.ResolveRelative(c.s.BasePath, "map")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, body)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/mediaupload.want
+++ b/google-api-go-generator/testdata/mediaupload.want
@@ -355,7 +355,7 @@ func (c *CaptionsInsertCall) doRequest(alt string) (*http.Response, error) {
 	newBody, getBody, cleanup := c.mediaInfo_.UploadRequest(reqHeaders, body)
 	defer cleanup()
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, newBody)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, newBody)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/param-rename.want
+++ b/google-api-go-generator/testdata/param-rename.want
@@ -221,7 +221,7 @@ func (c *EventsMoveCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "calendars/{calendarId}/events/{eventId}/move")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +330,7 @@ func (c *ReportsQueryCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "reports")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/repeated.want
+++ b/google-api-go-generator/testdata/repeated.want
@@ -255,7 +255,7 @@ func (c *AccountsReportsGenerateCall) doRequest(alt string) (*http.Response, err
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "accounts/{accountId}/reports")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/required-query.want
+++ b/google-api-go-generator/testdata/required-query.want
@@ -232,7 +232,7 @@ func (c *TechsCountCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "techs/count")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/google-api-go-generator/testdata/resource-named-service.want
+++ b/google-api-go-generator/testdata/resource-named-service.want
@@ -1819,7 +1819,7 @@ func (c *AppsGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1926,7 +1926,7 @@ func (c *AppsRepairCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}:repair")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2038,7 +2038,7 @@ func (c *AppsLocationsGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/locations/{locationsId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2169,7 +2169,7 @@ func (c *AppsLocationsListCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/locations")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2305,7 +2305,7 @@ func (c *AppsOperationsGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/operations/{operationsId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2438,7 +2438,7 @@ func (c *AppsOperationsListCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/operations")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2561,7 +2561,7 @@ func (c *AppsServicesDeleteCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2675,7 +2675,7 @@ func (c *AppsServicesGetCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2800,7 +2800,7 @@ func (c *AppsServicesListCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2955,7 +2955,7 @@ func (c *AppsServicesPatchCall) doRequest(alt string) (*http.Response, error) {
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("PATCH", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "PATCH", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3063,7 +3063,7 @@ func (c *AppsServicesVersionsCreateCall) doRequest(alt string) (*http.Response, 
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}/versions")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3168,7 +3168,7 @@ func (c *AppsServicesVersionsDeleteCall) doRequest(alt string) (*http.Response, 
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}/versions/{versionsId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3300,7 +3300,7 @@ func (c *AppsServicesVersionsGetCall) doRequest(alt string) (*http.Response, err
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}/versions/{versionsId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3441,7 +3441,7 @@ func (c *AppsServicesVersionsListCall) doRequest(alt string) (*http.Response, er
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}/versions")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3595,7 +3595,7 @@ func (c *AppsServicesVersionsPatchCall) doRequest(alt string) (*http.Response, e
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}/versions/{versionsId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("PATCH", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "PATCH", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3715,7 +3715,7 @@ func (c *AppsServicesVersionsInstancesDebugCall) doRequest(alt string) (*http.Re
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}/versions/{versionsId}/instances/{instancesId}:debug")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("POST", urls, body)
+	req, err := http.NewRequestWithContext(c.ctx_, "POST", urls, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3825,7 +3825,7 @@ func (c *AppsServicesVersionsInstancesDeleteCall) doRequest(alt string) (*http.R
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}/versions/{versionsId}/instances/{instancesId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("DELETE", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "DELETE", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -3947,7 +3947,7 @@ func (c *AppsServicesVersionsInstancesGetCall) doRequest(alt string) (*http.Resp
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}/versions/{versionsId}/instances/{instancesId}")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4080,7 +4080,7 @@ func (c *AppsServicesVersionsInstancesListCall) doRequest(alt string) (*http.Res
 	c.urlParams_.Set("prettyPrint", "false")
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/apps/{appsId}/services/{servicesId}/versions/{versionsId}/instances")
 	urls += "?" + c.urlParams_.Encode()
-	req, err := http.NewRequest("GET", urls, nil)
+	req, err := http.NewRequestWithContext(c.ctx_, "GET", urls, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Description
This pull request addresses an issue where network errors during BigQuery Storage API calls are not properly captured by APM (Application Performance Monitoring) tools due to missing context propagation in the generated HTTP client code.

Background
I encountered intermittent, seemingly invisible network failures when connecting to our Application Performance Monitoring (APM) system via the BigQuery Storage API.  My colleague identified a related issue in the google-cloud-go repository ([Issue #11364](https://github.com/googleapis/google-cloud-go/issues/11364)), which helped to guide my investigation.

To gain deeper insight into the problem, I attempted to integrate Datadog APM with our BigQuery client. Since a dedicated Datadog-compatible BigQuery client wasn't available, I implemented a custom HTTP transport to inject tracing into the client. However, despite this effort, no tracing data appeared in Datadog when using RowIterator.Next.

Problem
Upon further investigation into the google-api-go repository's code generator, I discovered a fundamental issue: the generated code for the doRequest method was not utilizing the available context. This prevents APM tools from properly capturing network requests and associated errors.

Solution
This PR modifies the code generator to correctly use the existing context from the Call interface when creating HTTP requests. Specifically, it changes the http.NewRequest call to http.NewRequestWithContext, ensuring that the context, including any APM tracing information, is propagated to the underlying HTTP client. This change should help to properly track those network requests and failures.