### PR TITLE
fix: Copy AllowHardBoundTokens option from old auth to new auth.

### DIFF
--- a/transport/grpc/dial.go
+++ b/transport/grpc/dial.go
@@ -242,7 +242,7 @@ func dialPoolNewAuth(ctx context.Context, secure bool, poolSize int, ds *interna
 			EnableDirectPath:                ds.EnableDirectPath,
 			EnableDirectPathXds:             ds.EnableDirectPathXds,
 			EnableJWTWithScope:              ds.EnableJwtWithScope,
-			AllowHardBoundTokens:            ds.AllowHardBoundTokens, 
+			AllowHardBoundTokens:            ds.AllowHardBoundTokens,
 			DefaultAudience:                 ds.DefaultAudience,
 			DefaultEndpointTemplate:         defaultEndpointTemplate,
 			DefaultMTLSEndpoint:             ds.DefaultMTLSEndpoint,

--- a/transport/grpc/dial.go
+++ b/transport/grpc/dial.go
@@ -242,6 +242,7 @@ func dialPoolNewAuth(ctx context.Context, secure bool, poolSize int, ds *interna
 			EnableDirectPath:                ds.EnableDirectPath,
 			EnableDirectPathXds:             ds.EnableDirectPathXds,
 			EnableJWTWithScope:              ds.EnableJwtWithScope,
+			AllowHardBoundTokens:            ds.AllowHardBoundTokens, 
 			DefaultAudience:                 ds.DefaultAudience,
 			DefaultEndpointTemplate:         defaultEndpointTemplate,
 			DefaultMTLSEndpoint:             ds.DefaultMTLSEndpoint,


### PR DESCRIPTION
Copy the new field AllowHardBoundTokens from the user options to the internal options in the new auth. The option was added in PR: https://github.com/googleapis/google-api-go-client/pull/2975