### PR TITLE
fix(googleapi): add JSON array support to CheckResponseWithBody

### DIFF
--- a/googleapi/googleapi.go
+++ b/googleapi/googleapi.go
@@ -184,11 +184,10 @@ func CheckResponseWithBody(res *http.Response, body []byte) error {
 // may be a JSON object or JSON array, or may be something else.
 func errorReplyFromBody(body []byte) (*errorReply, error) {
 	jerr := new(errorReply)
-	peekChar := body[0]
-	if peekChar == '[' {
+	if body[0] == '[' {
 		// Attempt JSON array
-		jsonArr := &[]*errorReply{jerr}
-		err := json.Unmarshal(body, jsonArr)
+		jsonArr := []*errorReply{jerr}
+		err := json.Unmarshal(body, &jsonArr)
 		return jerr, err
 	}
 	// Attempt JSON object

--- a/googleapi/googleapi.go
+++ b/googleapi/googleapi.go
@@ -163,8 +163,7 @@ func CheckResponseWithBody(res *http.Response, body []byte) error {
 		return nil
 	}
 
-	jerr := new(errorReply)
-	err := json.Unmarshal(body, jerr)
+	jerr, err := errorReplyFromBody(body)
 	if err == nil && jerr.Error != nil {
 		if jerr.Error.Code == 0 {
 			jerr.Error.Code = res.StatusCode
@@ -179,6 +178,22 @@ func CheckResponseWithBody(res *http.Response, body []byte) error {
 		Body:   string(body),
 		Header: res.Header,
 	}
+}
+
+// errorReplyFromBody attempts to get the error from body. The body
+// may be a JSON object or JSON array, or may be something else.
+func errorReplyFromBody(body []byte) (*errorReply, error) {
+	jerr := new(errorReply)
+	peekChar := body[0]
+	if peekChar == '[' {
+		// Attempt JSON array
+		jsonArr := &[]*errorReply{jerr}
+		err := json.Unmarshal(body, jsonArr)
+		return jerr, err
+	}
+	// Attempt JSON object
+	err := json.Unmarshal(body, jerr)
+	return jerr, err
 }
 
 // IsNotModified reports whether err is the result of the

--- a/googleapi/googleapi.go
+++ b/googleapi/googleapi.go
@@ -184,7 +184,7 @@ func CheckResponseWithBody(res *http.Response, body []byte) error {
 // may be a JSON object or JSON array, or may be something else.
 func errorReplyFromBody(body []byte) (*errorReply, error) {
 	jerr := new(errorReply)
-	if body[0] == '[' {
+	if len(body) > 0 && body[0] == '[' {
 		// Attempt JSON array
 		jsonArr := []*errorReply{jerr}
 		err := json.Unmarshal(body, &jsonArr)

--- a/googleapi/googleapi_test.go
+++ b/googleapi/googleapi_test.go
@@ -312,6 +312,19 @@ Details:
 		},
 		`googleapi: got HTTP response code 500 with body: {"error":{}}`,
 	},
+	{
+		// Case: Streaming error in JSON array in body.
+		&http.Response{
+			StatusCode: http.StatusTooManyRequests,
+		},
+		`[{"error":{"code": 429,"message": "Resource has been exhausted (e.g. check quota).","status": "RESOURCE_EXHAUSTED"}}]`,
+		&Error{
+			Code:    http.StatusTooManyRequests,
+			Message: "Resource has been exhausted (e.g. check quota).",
+			Body: "[{\"error\":{\"code\": 429,\"message\": \"Resource has been exhausted (e.g. check quota).\",\"status\": \"RESOURCE_EXHAUSTED\"}}]",
+		},
+		`googleapi: Error 429: Resource has been exhausted (e.g. check quota).`,
+	},
 }
 
 func TestCheckResponse(t *testing.T) {

--- a/googleapi/googleapi_test.go
+++ b/googleapi/googleapi_test.go
@@ -321,7 +321,7 @@ Details:
 		&Error{
 			Code:    http.StatusTooManyRequests,
 			Message: "Resource has been exhausted (e.g. check quota).",
-			Body:    "{\"error\":{\"code\": 429,\"message\": \"Resource has been exhausted (e.g. check quota).\",\"status\": \"RESOURCE_EXHAUSTED\"}}",
+			Body:    `{"error":{"code": 429,"message": "Resource has been exhausted (e.g. check quota).","status": "RESOURCE_EXHAUSTED"}}`,
 		},
 		`googleapi: Error 429: Resource has been exhausted (e.g. check quota).`,
 	},
@@ -334,7 +334,7 @@ Details:
 		&Error{
 			Code:    http.StatusTooManyRequests,
 			Message: "Resource has been exhausted (e.g. check quota).",
-			Body:    "[{\"error\":{\"code\": 429,\"message\": \"Resource has been exhausted (e.g. check quota).\",\"status\": \"RESOURCE_EXHAUSTED\"}}]",
+			Body:    `[{"error":{"code": 429,"message": "Resource has been exhausted (e.g. check quota).","status": "RESOURCE_EXHAUSTED"}}]`,
 		},
 		`googleapi: Error 429: Resource has been exhausted (e.g. check quota).`,
 	},

--- a/googleapi/googleapi_test.go
+++ b/googleapi/googleapi_test.go
@@ -321,7 +321,7 @@ Details:
 		&Error{
 			Code:    http.StatusTooManyRequests,
 			Message: "Resource has been exhausted (e.g. check quota).",
-			Body: "[{\"error\":{\"code\": 429,\"message\": \"Resource has been exhausted (e.g. check quota).\",\"status\": \"RESOURCE_EXHAUSTED\"}}]",
+			Body:    "[{\"error\":{\"code\": 429,\"message\": \"Resource has been exhausted (e.g. check quota).\",\"status\": \"RESOURCE_EXHAUSTED\"}}]",
 		},
 		`googleapi: Error 429: Resource has been exhausted (e.g. check quota).`,
 	},

--- a/googleapi/googleapi_test.go
+++ b/googleapi/googleapi_test.go
@@ -313,6 +313,19 @@ Details:
 		`googleapi: got HTTP response code 500 with body: {"error":{}}`,
 	},
 	{
+		// Case: Error in JSON object in body.
+		&http.Response{
+			StatusCode: http.StatusTooManyRequests,
+		},
+		`{"error":{"code": 429,"message": "Resource has been exhausted (e.g. check quota).","status": "RESOURCE_EXHAUSTED"}}`,
+		&Error{
+			Code:    http.StatusTooManyRequests,
+			Message: "Resource has been exhausted (e.g. check quota).",
+			Body:    "{\"error\":{\"code\": 429,\"message\": \"Resource has been exhausted (e.g. check quota).\",\"status\": \"RESOURCE_EXHAUSTED\"}}",
+		},
+		`googleapi: Error 429: Resource has been exhausted (e.g. check quota).`,
+	},
+	{
 		// Case: Streaming error in JSON array in body.
 		&http.Response{
 			StatusCode: http.StatusTooManyRequests,


### PR DESCRIPTION
fixes: googleapis/gax-go#389


```
R.......R......R.....R.......R......R......R.....R.......R.......R.......R
2025/03/20 15:59:31 googleapi: Error 429: Resource has been exhausted (e.g. check quota).
```