### PR TITLE
fix: check for auth creds in options to trigger new auth lib usage

### DIFF
--- a/internal/settings.go
+++ b/internal/settings.go
@@ -110,6 +110,9 @@ func (ds *DialSettings) IsNewAuthLibraryEnabled() bool {
 	if ds.EnableNewAuthLibrary {
 		return true
 	}
+	if ds.AuthCredentials != nil {
+		return true
+	}
 	if b, err := strconv.ParseBool(os.Getenv(newAuthLibEnvVar)); err == nil {
 		return b
 	}


### PR DESCRIPTION
If a user explicitly sends in a new auth credential we should use it in the context of our new auth stack as the older transports don't respect the AuthCredential dial setting.

Internal Bug: 419103794