### PR TITLE
docs(internaloption): fix AuthCreds bulleted list format

### DIFF
--- a/option/internaloption/internaloption.go
+++ b/option/internaloption/internaloption.go
@@ -289,21 +289,21 @@ func GetLogger(opts []option.ClientOption) *slog.Logger {
 // options provided via [option.ClientOption], including legacy oauth2/google
 // options, in this order:
 //
-// * [option.WithAuthCredentials]
-// * [option/internaloption.WithCredentials] (internal use only)
-// * [option.WithCredentials]
-// * [option.WithTokenSource]
+//   - [option.WithAuthCredentials]
+//   - [option/internaloption.WithCredentials] (internal use only)
+//   - [option.WithCredentials]
+//   - [option.WithTokenSource]
 //
 // If there are no applicable credentials options, then it passes the
 // following options to [cloud.google.com/go/auth/credentials.DetectDefault] and
 // returns the result:
 //
-// * [option.WithAudiences]
-// * [option.WithCredentialsFile]
-// * [option.WithCredentialsJSON]
-// * [option.WithScopes]
-// * [option/internaloption.WithDefaultScopes] (internal use only)
-// * [option/internaloption.EnableJwtWithScope] (internal use only)
+//   - [option.WithAudiences]
+//   - [option.WithCredentialsFile]
+//   - [option.WithCredentialsJSON]
+//   - [option.WithScopes]
+//   - [option/internaloption.WithDefaultScopes] (internal use only)
+//   - [option/internaloption.EnableJwtWithScope] (internal use only)
 //
 // This function should only be used internally by generated clients. This is an
 // EXPERIMENTAL API and may be changed or removed in the future.


### PR DESCRIPTION
Currently broken, need two leading spaces before list item marker.

![image](https://github.com/user-attachments/assets/b455f28c-4d4e-4849-9649-46549e3aad1d)

Switched to dash (aligns with gofmt rec and other examples in code).
