### PR TITLE
chore: update CODEOWNERS, remove blunderbuss

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Default owner for all directories not owned by others
-* @googleapis/yoshi-go-admins
+* @googleapis/cloud-sdk-go-eng
 
 # Also give @yoshi-approver owners for all generated files.
-*.json @yoshi-approver @googleapis/yoshi-go-admins
-*-gen.go @yoshi-approver @googleapis/yoshi-go-admins
+*.json @yoshi-approver @googleapis/cloud-sdk-go-eng
+*-gen.go @yoshi-approver @googleapis/cloud-sdk-go-eng
 

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,2 +1,0 @@
-assign_issues:
-- codyoss


### PR DESCRIPTION
Swap out yoshi-go-admins for cloud-sdk-go-eng, and remove blunderbuss because it simply routed everything to cody