### PR TITLE
feat(transport/grpc): add a getter for grpcconnpool size

### DIFF
--- a/transport/grpc/dial.go
+++ b/transport/grpc/dial.go
@@ -552,6 +552,16 @@ func processAndValidateOpts(opts []option.ClientOption) (*internal.DialSettings,
 	return &o, nil
 }
 
+// UserConfiguredGRPCConnPoolSize processes the client options and returns the configured
+// gRPC connection pool size. It returns an error if the provided options are invalid.
+func UserConfiguredGRPCConnPoolSize(opts ...option.ClientOption) (int, error) {
+	o, err := processAndValidateOpts(opts)
+	if err != nil {
+		return 0, err
+	}
+	return o.GRPCConnPoolSize, nil
+}
+
 type connPoolOption struct{ ConnPool }
 
 // WithConnPool returns a ClientOption that specifies the ConnPool


### PR DESCRIPTION
The Bigtable Go client library allows users to configure the underlying gRPC connection pool size using option.WithGRPCConnectionPool(size) when creating a new client. However, the Bigtable client code itself has no direct way to access the size value that the user provided. This is because the option is applied to an internal DialSettings struct within the google.golang.org/api dependencies, and the final pool size is not exposed.

We need to access this size to use the custom Bigtable Channel Pool. 
