### PR TITLE
fix(internal): prevent duplicate credential options in AuthCreds

### DIFF
--- a/internal/creds.go
+++ b/internal/creds.go
@@ -58,6 +58,16 @@ func AuthCreds(ctx context.Context, settings *DialSettings) (*auth.Credentials, 
 	if settings.AuthCredentials != nil {
 		return settings.AuthCredentials, nil
 	}
+	// If the user provided credentials via JSON or file options, return nil
+	// to let the transport handle credential detection later. This prevents
+	// client libraries from adding duplicate WithAuthCredentials options.
+	if len(settings.AuthCredentialsJSON) > 0 || settings.AuthCredentialsFile != "" {
+		return nil, nil
+	}
+	// Also check for legacy credential options (CredentialsJSON, CredentialsFile)
+	if len(settings.CredentialsJSON) > 0 || settings.CredentialsFile != "" {
+		return nil, nil
+	}
 	// Support oauth2/google options
 	var oauth2Creds *google.Credentials
 	if settings.InternalCredentials != nil {


### PR DESCRIPTION
## Problem

When a user passes credentials via `option.WithCredentialsJSON()` or `option.WithCredentialsFile()`, client libraries (like storage, bigquery, etc.) call `internaloption.AuthCreds()` to pre-detect credentials. This function falls through to `detectDefaultFromDialSettings()`, creates credentials from the user's JSON/file, and returns them. The client then adds `option.WithAuthCredentials(creds)` to the options.

This results in **both** `CredentialsJSON` and `AuthCredentials` being set on the DialSettings, causing validation to fail with:

```
dialing: multiple credential options provided
```

## Root Cause

`AuthCreds()` checks for `AuthCredentials` before falling through to detection, but does not check for credential JSON/file options (both legacy and new variants). This causes it to detect and return credentials even when the user already provided them.

### Code Path

1. User: `storage.NewClient(ctx, option.WithCredentialsJSON(json))`
2. `WithCredentialsJSON` sets `ds.CredentialsJSON`
3. Storage calls `internaloption.AuthCreds(ctx, opts)` (storage.go:172)
4. `AuthCreds` doesn't check for `CredentialsJSON`, falls through to `detectDefaultFromDialSettings`
5. Detection reads user's JSON via `GetAuthCredentialsJSON()` (which falls back to `CredentialsJSON`) and creates `*auth.Credentials`
6. Storage adds `option.WithAuthCredentials(creds)` - now setting `ds.AuthCredentials`
7. Validation sees both `CredentialsJSON` AND `AuthCredentials` = 2 sources = **error**

## Fix

Return `nil` early from `AuthCreds()` when any credential JSON/file option is already set:
- `AuthCredentialsJSON`
- `AuthCredentialsFile`  
- `CredentialsJSON` (legacy)
- `CredentialsFile` (legacy)

This allows the transport to handle credential detection later without the client library adding a duplicate `WithAuthCredentials` option.

## Testing

- [x] `go test ./internal/...` passes
- [x] Verified fix with reproduction case: `storage.NewClient(ctx, option.WithCredentialsJSON(json))` with `GOOGLE_APPLICATION_CREDENTIALS` set now succeeds

Fixes googleapis/google-cloud-go#13503