### PR TITLE
fix(option): remove option.WithAuthCredentials from validation

### DIFF
--- a/internal/settings.go
+++ b/internal/settings.go
@@ -165,6 +165,9 @@ func (ds *DialSettings) Validate() error {
 		return errors.New("options.WithoutAuthentication is incompatible with any option that provides credentials")
 	}
 	// Credentials should not appear with other options.
+	// AuthCredentials is a special case that may be present with
+	// with other options in order to facilitate automatic conversion of
+	// oauth2 types (old auth) to cloud.google.com/go/auth types (new auth).
 	// We currently allow TokenSource and CredentialsFile to coexist.
 	// TODO(jba): make TokenSource & CredentialsFile an error (breaking change).
 	nCreds := 0
@@ -172,9 +175,6 @@ func (ds *DialSettings) Validate() error {
 		nCreds++
 	}
 	if len(ds.CredentialsJSON) > 0 {
-		nCreds++
-	}
-	if ds.AuthCredentials != nil {
 		nCreds++
 	}
 	if len(ds.AuthCredentialsJSON) > 0 {

--- a/internal/settings_test.go
+++ b/internal/settings_test.go
@@ -29,7 +29,9 @@ func TestSettingsValidate(t *testing.T) {
 		{Scopes: []string{"s"}},
 		{CredentialsFile: "f"},
 		{TokenSource: dummyTS{}},
-		{CredentialsFile: "f", TokenSource: dummyTS{}}, // keep for backwards compatibility
+		{Credentials: &google.DefaultCredentials{}, AuthCredentials: &auth.Credentials{}}, // Support old auth to new auth automatic conversions
+		{CredentialsFile: "f", AuthCredentials: &auth.Credentials{}},                      // Support old auth to new auth automatic conversions
+		{CredentialsFile: "f", TokenSource: dummyTS{}},                                    // keep for backwards compatibility
 		{CredentialsJSON: []byte("json")},
 		{AuthCredentialsFile: "f"},
 		{AuthCredentialsJSON: []byte("json")},
@@ -56,6 +58,7 @@ func TestSettingsValidate(t *testing.T) {
 		{NoAuth: true, AuthCredentialsFile: "f"},
 		{NoAuth: true, TokenSource: dummyTS{}},
 		{NoAuth: true, Credentials: &google.DefaultCredentials{}},
+		{NoAuth: true, AuthCredentials: &auth.Credentials{}},
 		{NoAuth: true, AuthCredentialsJSON: []byte("json")},
 		{Credentials: &google.DefaultCredentials{}, CredentialsFile: "f"},
 		{Credentials: &google.DefaultCredentials{}, AuthCredentialsFile: "f"},


### PR DESCRIPTION
Do not raise the multiple credential options provided error when
option.WithAuthCredentials is provided with other auth configuration
options, as it is a special case used internally for oauth2 type converversions.

fixes: googleapis/google-cloud-go#13503