### PR TITLE
chore(all): Replace strings.Replace with strings.ReplaceAll

### DIFF
--- a/google-api-go-generator/gen_test.go
+++ b/google-api-go-generator/gen_test.go
@@ -100,7 +100,7 @@ func TestAPIs(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			wantStr := strings.Replace(string(want), "gdcl/00000000", fmt.Sprintf("gdcl/%s", internal.Version), -1)
+			wantStr := strings.ReplaceAll(string(want), "gdcl/00000000", fmt.Sprintf("gdcl/%s", internal.Version))
 			if !bytes.Equal([]byte(wantStr), clean) {
 				tf, _ := os.CreateTemp("", "api-"+name+"-got-json.")
 				if _, err := tf.Write(clean); err != nil {
@@ -119,7 +119,7 @@ func TestAPIs(t *testing.T) {
 func readOrUpdate(name, clean string) ([]byte, error) {
 	goldenFile := goldenFileName(name)
 	if *updateGolden {
-		clean := strings.Replace(string(clean), fmt.Sprintf("gdcl/%s", internal.Version), "gdcl/00000000", -1)
+		clean := strings.ReplaceAll(string(clean), fmt.Sprintf("gdcl/%s", internal.Version), "gdcl/00000000")
 		if err := os.WriteFile(goldenFile, []byte(clean), 0644); err != nil {
 			return nil, err
 		}

--- a/googleapi/googleapi.go
+++ b/googleapi/googleapi.go
@@ -393,9 +393,9 @@ func ResolveRelative(basestr, relstr string) string {
 	if afterColonPath != "" {
 		us = fmt.Sprintf("%s:%s", us, afterColonPath)
 	}
-	us = strings.Replace(us, "%7B", "{", -1)
-	us = strings.Replace(us, "%7D", "}", -1)
-	us = strings.Replace(us, "%2A", "*", -1)
+	us = strings.ReplaceAll(us, "%7B", "{")
+	us = strings.ReplaceAll(us, "%7D", "}")
+	us = strings.ReplaceAll(us, "%2A", "*")
 	return us
 }
 


### PR DESCRIPTION
Refactored code in gen_test.go and googleapi.go to use strings.ReplaceAll instead of strings.Replace for improved readability and clarity. This change simplifies string replacement operations by removing the need to specify -1 as the count.