### PR TITLE
chore: Update CRM service initialization in paging tests

### DIFF
--- a/google-api-go-generator/paging_test.go
+++ b/google-api-go-generator/paging_test.go
@@ -69,8 +69,7 @@ func TestPagesParam(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client := &http.Client{}
-	s, err := crm.New(client)
+	s, err := crm.NewService(context.TODO())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,8 +117,7 @@ func TestPagesRequestField(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client := &http.Client{}
-	s, err := crm.New(client)
+	s, err := crm.NewService(context.TODO())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Replaces usage of crm.New with crm.NewService and context.TODO() in TestPagesParam and TestPagesRequestField to align with updated API initialization patterns.