### PR TITLE
feat(transport/grpc): add function to get reason for direct path incompatibility

### DIFF
--- a/transport/grpc/dial.go
+++ b/transport/grpc/dial.go
@@ -565,6 +565,7 @@ const (
 	statusAPIKey                   = "api_key"
 	statusMissingTokenSource       = "missing_token_source"
 	statusTokenFetchError          = "token_fetch_error"
+	statusNilToken                 = "nil_token"
 	statusNotComputeMetadata       = "not_compute_metadata"
 	statusNotDefaultServiceAccount = "not_default_service_account"
 )
@@ -647,7 +648,7 @@ func checkAuthStatus(ctx context.Context, o *internal.DialSettings) string {
 		return statusTokenFetchError
 	}
 	if tok == nil {
-		return statusTokenFetchError
+		return statusNilToken
 	}
 
 	// AllowNonDefaultServiceAccount bypasses the metadata source and default account checks.

--- a/transport/grpc/dial_test.go
+++ b/transport/grpc/dial_test.go
@@ -415,6 +415,13 @@ func TestCheckAuthStatus(t *testing.T) {
 			},
 			want: statusTokenFetchError,
 		},
+		{
+			name: "Nil Token - Incompatible",
+			ds: &internal.DialSettings{
+				TokenSource: &mockTokenSource{token: nil}, // Token() returns (nil, nil)
+			},
+			want: statusNilToken,
+		},
 	}
 
 	for _, tt := range tests {
@@ -546,6 +553,17 @@ func TestCheckDirectPathStatus(t *testing.T) {
 			},
 			onGCE: true,
 			want:  statusTokenFetchError,
+		},
+		{
+			name: "Nil token returned",
+			opts: []option.ClientOption{
+				internaloption.EnableDirectPath(true),
+				internaloption.EnableDirectPathXds(),
+				validEndpoint,
+				option.WithTokenSource(&mockTokenSource{token: nil}),
+			},
+			onGCE: true,
+			want:  statusNilToken,
 		},
 		{
 			name: "Incompatible credentials - Not compute metadata",


### PR DESCRIPTION
Adds DirectPathStatus and CheckWithReason to categorize why DirectPath is used or disabled  into fallback reasons. This enables better observability.