### PR TITLE
fix(generator): handle preview version pkg name

### DIFF
--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -467,6 +467,9 @@ func renameVersion(version string) string {
 	if version == "alpha" || version == "beta" {
 		return "v0." + version
 	}
+	if version == "preview" {
+		return "v1.preview"
+	}
 	if m := oddVersionRE.FindStringSubmatch(version); m != nil {
 		return m[1] + "/" + m[2]
 	}

--- a/google-api-go-generator/gen_test.go
+++ b/google-api-go-generator/gen_test.go
@@ -237,6 +237,18 @@ func TestRenameVersion(t *testing.T) {
 			version: "my_api_v1.2",
 			want:    "my_api/v1.2",
 		},
+		{
+			version: "alpha",
+			want:    "v0.alpha",
+		},
+		{
+			version: "beta",
+			want:    "v0.beta",
+		},
+		{
+			version: "preview",
+			want:    "v1.preview",
+		},
 	}
 	for _, test := range tests {
 		if got := renameVersion(test.version); got != test.want {


### PR DESCRIPTION
Similar to how we have special package name handling for `alpha` and `beta` to make them align more closely with Go package naming, we need to do the same for `preview`, which will be coming in the future. We will use `v1` instead of `v0` as the target API adopting this will be basing their preview on an existing `v1`, and a majority of APIs start with `v1` anyways. 

Also adds missing test cases for the existing conditions in addition to the new one.

Internal issue http://b/475856585