### PR TITLE
chore(google-api-go-generator): restore aiplatform:v1beta1

### DIFF
--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -79,8 +79,6 @@ var skipAPIGeneration = map[string]bool{
 	"integrations:v1":      true,
 	"sql:v1beta4":          true,
 	"datalineage:v1":       true,
-	// Restore aiplatform:v1beta1 after b/446965637 is resolved.
-	"aiplatform:v1beta1": true,
 }
 
 var apisToSplit = map[string]bool{


### PR DESCRIPTION
Although the schema shape (nested arrays of any) has not changed, running generation locally no longer produces the error caused by nested arrays of any for ConfusionMatrixRows.

See internal b/446965637 for details.

refs: #3317