### PR TITLE
chore: embargo discoveryengine:v1 from generation

### DIFF
--- a/google-api-go-generator/gen.go
+++ b/google-api-go-generator/gen.go
@@ -81,6 +81,7 @@ var skipAPIGeneration = map[string]bool{
 	"datalineage:v1":          true,
 	"aiplatform:v1beta1":      true,
 	"discoveryengine:v1alpha": true,
+	"discoveryengine:v1":      true,
 }
 
 var apisToSplit = map[string]bool{


### PR DESCRIPTION
related: internal b/501474128