### PR TITLE
chore: downgrade min Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module google.golang.org/api
 
-go 1.25.8
+go 1.25.0
 
 retract v0.258.0 // due to https://github.com/googleapis/google-cloud-go/issues/13503
 


### PR DESCRIPTION
related to https://github.com/googleapis/google-api-go-client/pull/3605#discussion_r3320867839