### PR TITLE
docs: remove old TODO file

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,2 +1,0 @@
-Moved to:
-https://github.com/google/google-api-go-client/issues


### PR DESCRIPTION
This PR ditches the TODO file, which hasn't been used in more than a decade versus issue tracking.