### PR TITLE
chore: constrain go version updates in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,11 @@
   ],
   "packageRules": [
     {
+      "description": "prevent go version upgrades",
+      "matchManagers": ["gomod"],
+      "constraintsFiltering": "strict"
+    },
+    {
       "matchPackagePatterns": [
         "^github.com/google/go-github/v",
         "^go.opentelemetry.io/contrib/instrumentation/"


### PR DESCRIPTION
https://docs.renovatebot.com/modules/manager/gomod/#only-suggesting-updates-that-match-your-go-directive