### PR TITLE
fix(idtoken): validate ES256 signature length before slicing

### DIFF
--- a/idtoken/validate.go
+++ b/idtoken/validate.go
@@ -229,6 +229,14 @@ func (v *Validator) validateES256(ctx context.Context, keyID string, hashedConte
 		X:     new(big.Int).SetBytes(dx),
 		Y:     new(big.Int).SetBytes(dy),
 	}
+	// Validate the signature length before slicing. A JWT with a signature
+	// segment that decodes to fewer than es256KeySize*2 bytes would otherwise
+	// cause an unrecovered panic ("slice bounds out of range") here, since
+	// sig[:es256KeySize] and sig[es256KeySize:] assume exactly two
+	// es256KeySize-byte components (r and s) with no length check.
+	if len(sig) != es256KeySize*2 {
+		return fmt.Errorf("idtoken: invalid ES256 signature length: got %d bytes, want %d", len(sig), es256KeySize*2)
+	}
 	r := big.NewInt(0).SetBytes(sig[:es256KeySize])
 	s := big.NewInt(0).SetBytes(sig[es256KeySize:])
 	if valid := ecdsa.Verify(pk, hashedContent, r, s); !valid {

--- a/idtoken/validate_test.go
+++ b/idtoken/validate_test.go
@@ -285,6 +285,96 @@ func createES256JWT(t *testing.T) (string, ecdsa.PublicKey) {
 	return token.String(), privateKey.PublicKey
 }
 
+// TestValidateES256_ShortSignature confirms that a JWT whose ES256 signature
+// segment decodes to fewer than es256KeySize*2 bytes is rejected with an
+// error rather than causing an unrecovered panic.
+func TestValidateES256_ShortSignature(t *testing.T) {
+	token := commonToken(t, "ES256")
+	token.signature = base64.RawURLEncoding.EncodeToString([]byte{0x01, 0x02, 0x03})
+	idToken := token.String()
+
+	client := &http.Client{
+		Transport: RoundTripFn(func(req *http.Request) *http.Response {
+			cr := certResponse{
+				Keys: []jwk{
+					{
+						Kid: keyID,
+						X:   base64.RawURLEncoding.EncodeToString([]byte{0x01}),
+						Y:   base64.RawURLEncoding.EncodeToString([]byte{0x01}),
+					},
+				},
+			}
+			b, err := json.Marshal(&cr)
+			if err != nil {
+				t.Fatalf("unable to marshal response: %v", err)
+			}
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+				Header:     make(http.Header),
+			}
+		}),
+	}
+	oldNow := now
+	defer func() { now = oldNow }()
+	now = beforeExp
+
+	v, err := NewValidator(context.Background(), option.WithHTTPClient(client))
+	if err != nil {
+		t.Fatalf("NewValidator(...) = %q, want nil", err)
+	}
+
+	_, err = v.Validate(context.Background(), idToken, testAudience)
+	if err == nil {
+		t.Fatalf("Validate(ctx, %s, %s) = nil, want error for short ES256 signature", idToken, testAudience)
+	}
+}
+
+// TestValidateES256_OverlongSignature confirms that an oversized ES256
+// signature is also rejected, rather than being silently truncated.
+func TestValidateES256_OverlongSignature(t *testing.T) {
+	token := commonToken(t, "ES256")
+	overlong := make([]byte, es256KeySize*2+1)
+	token.signature = base64.RawURLEncoding.EncodeToString(overlong)
+	idToken := token.String()
+
+	client := &http.Client{
+		Transport: RoundTripFn(func(req *http.Request) *http.Response {
+			cr := certResponse{
+				Keys: []jwk{
+					{
+						Kid: keyID,
+						X:   base64.RawURLEncoding.EncodeToString([]byte{0x01}),
+						Y:   base64.RawURLEncoding.EncodeToString([]byte{0x01}),
+					},
+				},
+			}
+			b, err := json.Marshal(&cr)
+			if err != nil {
+				t.Fatalf("unable to marshal response: %v", err)
+			}
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+				Header:     make(http.Header),
+			}
+		}),
+	}
+	oldNow := now
+	defer func() { now = oldNow }()
+	now = beforeExp
+
+	v, err := NewValidator(context.Background(), option.WithHTTPClient(client))
+	if err != nil {
+		t.Fatalf("NewValidator(...) = %q, want nil", err)
+	}
+
+	_, err = v.Validate(context.Background(), idToken, testAudience)
+	if err == nil {
+		t.Fatalf("Validate(ctx, %s, %s) = nil, want error for overlong ES256 signature", idToken, testAudience)
+	}
+}
+
 func createRS256JWT(t *testing.T) (string, rsa.PublicKey) {
 	t.Helper()
 	token := commonToken(t, "RS256")


### PR DESCRIPTION
## Problem

`idtoken.Validator.Validate()` panics with an unrecovered runtime error when given a JWT signed with `alg: ES256` whose signature segment decodes to fewer than 32 bytes. Any service using this package to validate incoming Google-issued ID tokens (e.g. Cloud Run, Cloud Functions, custom services authenticating callers via bearer tokens) can be crashed by a single malformed ~120-byte JWT.

## Root Cause

`idtoken/validate.go`, `validateES256`:
```
r := big.NewInt(0).SetBytes(sig[:es256KeySize])   // panics if len(sig) < 32
s := big.NewInt(0).SetBytes(sig[es256KeySize:])
```

`findMatchingKey` only checks that the JWT's `kid` header matches a known key ID — it does not validate the signature at that point. The JWKS endpoint (`googleIAPCertsURL`) is public and unauthenticated by design, so any attacker can retrieve a real, currently valid `kid` with a single unauthenticated GET request, then craft a JWT with that `kid` and a signature under 32 bytes to trigger the panic.

## Fix

Adds an exact-length check before slicing:
```
if len(sig) != es256KeySize*2 {
    return fmt.Errorf("idtoken: invalid ES256 signature length: got %d bytes, want %d", len(sig), es256KeySize*2)
}
```

This also incidentally fixes a related correctness issue: signatures longer than 64 bytes were previously silently truncated to the first 64 bytes without error (only the exact-length check catches both directions).

## Testing

Two new regression tests in `idtoken/validate_test.go`:
- `TestValidateES256_ShortSignature`: a 3-byte signature must return an error, not panic
- `TestValidateES256_OverlongSignature`: a 65-byte signature must also return an error

Both use the package's real, unmodified, exported `Validator.Validate()` entry point via the existing `RoundTripFn`/`commonToken` test helpers — no reimplementation.

---