### PR TITLE
fix(impersonate): exchange user JWTs with RFC 7523 jwt-bearer grant

### DIFF
--- a/impersonate/user.go
+++ b/impersonate/user.go
@@ -142,8 +142,7 @@ func (u userTokenSource) signJWT() (string, error) {
 func (u userTokenSource) exchangeToken(signedJWT string) (*oauth2.Token, error) {
 	now := time.Now()
 	v := url.Values{}
-	v.Set("grant_type", "assertion")
-	v.Set("assertion_type", "http://oauth.net/grant_type/jwt/1.0/bearer")
+	v.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
 	v.Set("assertion", signedJWT)
 	rawResp, err := u.client.PostForm(fmt.Sprintf("%s/token", oauth2Endpoint), v)
 	if err != nil {


### PR DESCRIPTION
Fixes #3671

The user (Subject) flow exchanged the signJwt-signed JWT at oauth2.googleapis.com/token using the pre-RFC 7523 legacy grant (grant_type=assertion). Since mid-July 2026 that path rejects JWTs signed with recently-rotated system-managed keys with "invalid_grant: Invalid JWT Signature". Exchange with the standard urn:ietf:params:oauth:grant-type:jwt-bearer grant instead, matching google-auth-library-python's behavior for the same flow.
