### PR TITLE
test(transport/http): revert change to TestNewClient

### DIFF
--- a/transport/http/dial_test.go
+++ b/transport/http/dial_test.go
@@ -25,7 +25,7 @@ func TestNewClient(t *testing.T) {
 	if endpoint != "" {
 		t.Errorf("got: %s, want: ''", endpoint)
 	}
-	if got, want := fmt.Sprintf("%T", client.Transport), "*oauth2.Transport"; got != want {
+	if got, want := fmt.Sprintf("%T", client.Transport), "*httptransport.authTransport"; got != want {
 		t.Fatalf("got %s, want: %s", got, want)
 	}
 }


### PR DESCRIPTION
This PR reverts a change from PR3660 that altered expectations about transport.  Local testing and CI testing are especially sensitive to env setup, and this test is tied to our CI setup.  There's some future opportunities here to test multiple auth setups, but it is not this day.  This day I just want the tests to go green again.